### PR TITLE
deleting install-breaking lines in plugin header

### DIFF
--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -1,10 +1,8 @@
 <?php
 /*
  * Plugin Name: WooCommerce Reepay Checkout Gateway
- * Plugin URI: #
  * Description: Provides a Payment Gateway through Reepay for WooCommerce.
  * Author: AAIT
- * Author URI: #
  * Version: 1.1.16
  * Text Domain: woocommerce-gateway-reepay-checkout
  * Domain Path: /languages


### PR DESCRIPTION
At the moment the plugin is in the WordPress plugin library even though it is not possible to install the plugin do to "hashtags" in the plugin header. Those lines that are hashtagged are not obligatory and there fore I have deleted them.