### PR TITLE
Enhanched the capture_payment to settle lower amount than authorized

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway-reepay.php
+++ b/includes/abstracts/abstract-wc-payment-gateway-reepay.php
@@ -125,7 +125,10 @@ abstract class WC_Payment_Gateway_Reepay extends WC_Payment_Gateway
 		}
 
 		try {
-			$result = $this->request( 'POST', 'https://api.reepay.com/v1/charge/' . $handle . '/settle' );
+			$params = [
+				'amount' => $amount * 100,
+			];
+			$result = $this->request( 'POST', 'https://api.reepay.com/v1/charge/' . $handle . '/settle', $params );
 		} catch ( Exception $e ) {
 			throw new Exception( sprintf( 'API Error: %s', $e->getMessage() ) );
 		}


### PR DESCRIPTION
If an order was created with totals 100,00, then edited with new totals 75,00 the full amount was settled at Reepay using the /charge api.
Now the re-calculated order totals is forwarded to Reepay when the capture is made from WooCommerce