### PR TITLE
Fix for order auto-cancel

### DIFF
--- a/includes/class-wc-gateway-reepay-checkout.php
+++ b/includes/class-wc-gateway-reepay-checkout.php
@@ -80,6 +80,11 @@ class WC_Gateway_Reepay_Checkout extends WC_Payment_Gateway_Reepay {
 	 * Skip order lines to Reepay and use order totals instead
 	 */
 	public $skip_order_lines = 0;
+	
+	/**
+	 * If automatically cancel inpaid orders should be ignored
+	 */
+	public $disable_order_autocancel = 0;
 
 	/**
 	 * Init
@@ -126,6 +131,7 @@ class WC_Gateway_Reepay_Checkout extends WC_Payment_Gateway_Reepay {
 		$this->logos            = isset( $this->settings['logos'] ) ? $this->settings['logos'] : $this->logos;
 		$this->payment_type     = isset( $this->settings['payment_type'] ) ? $this->settings['payment_type'] : $this->payment_type;
 		$this->skip_order_lines = isset( $this->settings['skip_order_lines'] ) ? $this->settings['skip_order_lines'] : $this->skip_order_lines;
+		$this->disable_order_autocancel = isset( $this->settings['disable_order_autocancel'] ) ? $this->settings['disable_order_autocancel'] : $this->disable_order_autocancel;
 
 		// Disable "Add payment method" if the CC saving is disabled
 		if ( $this->save_cc !== 'yes' && ($key = array_search('add_payment_method', $this->supports)) !== false ) {
@@ -341,6 +347,16 @@ class WC_Gateway_Reepay_Checkout extends WC_Payment_Gateway_Reepay {
 					1  => 'Skip order lines'
 				),
 				'default'     => $this->skip_order_lines
+			),
+			'disable_order_autocancel' => array(
+				'title'       => __( 'Disable order auto-cancel', 'woocommerce-gateway-reepay-checkout' ),
+				'description'    => __( 'If the automatic woocommerce unpaid order auto-cancel should be ignored' ),
+				'type'        => 'select',
+				'options'     => array(
+					0 => 'Enable auto-cancel',
+					1  => 'Ignore / disable auto-cancel'
+				),
+				'default'     => $this->disable_order_autocancel
 			)
 		);
 	}

--- a/includes/class-wc-reepay-order-statuses.php
+++ b/includes/class-wc-reepay-order-statuses.php
@@ -428,9 +428,21 @@ class WC_Reepay_Order_Statuses {
 	 *
 	 * @return bool
 	 */
-	public function cancel_unpaid_order( $is_cancel, $is_checkout, $order ) {
+	public function cancel_unpaid_order( $is_cancel, $order ) {
+		//
+		// Fetch gateway module for the 
+		//
+		$payment_method = $order->get_payment_method();
+		$gateways = WC()->payment_gateways()->get_available_payment_gateways();
+		$gateway = 	$gateways[ $payment_method ];
+		
+		//
+		// Now set the flag if auto-cancel is enabled or not
+		//
 		if ( in_array( $order->get_payment_method(), WC_ReepayCheckout::PAYMENT_METHODS ) ) {
-			$is_cancel = false;
+			if ( $gateway->disable_order_autocancel == 1 ) {
+				$is_cancel = false;
+			}
 		}
 
 		return $is_cancel;

--- a/templates/admin/action-buttons.php
+++ b/templates/admin/action-buttons.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 
-<?php if ( $gateway->can_capture( $order ) || true ): ?>
+<?php if ( $gateway->can_capture( $order ) ): ?>
 	<button id="reepay_capture"
 			type="button" class="button button-primary"
 			data-nonce="<?php echo wp_create_nonce( 'reepay' ); ?>"


### PR DESCRIPTION
Fix so orders can be auto-cancelled. This is done by setting in the back-office (on the gateway) by the setting disable_order_autocancel