### PR TITLE
Fix deprecation error

### DIFF
--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -196,7 +196,7 @@ class WC_ReepayCheckout {
 	/**
 	 * Add notices
 	 */
-	public function may_add_notices() {
+	public static function may_add_notices() {
 		// Check if WooCommerce is missing
 		if ( ! class_exists( 'WooCommerce', false ) || ! defined( 'WC_ABSPATH' ) ) {
 			add_action( 'admin_notices', __CLASS__ . '::missing_woocommerce_notice' );


### PR DESCRIPTION
Init action was static calling non-static method `may_add_notices` and causing a E_DEPRECATED warning in PHP 7.4.