### PR TITLE
Patch Fix WP warning message WC_Reepay_Renewals

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -4,7 +4,7 @@ Tags: billwerk+, visa, mastercard, dankort, mobilepay
 Requires at least: 4.0
 Tested up to: 6.5.3
 Requires PHP: 7.4
-Stable tag: 1.7.7
+Stable tag: 1.7.7.1
 License: GPL
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -18,6 +18,9 @@ The Billwerk+ Pay plugin extends WooCommerce allowing you to take payments on yo
 See installation guide right here: https://docu.billwerk.plus/help/en/apps/woocommerce/setup-woocommerce-plugin.html
 
 == Changelog ==
+v 1.7.7.1 -
+* [Fix] - WP warning message The use statement with non-compound name WC_Reepay_Renewals has no effect.
+
 v 1.7.7 -
 * [Fix] - Missing payment_method_reference data in the Billwerk+ customer_payment_method_added webhook could cause PHP fatal error.
 * [Fix] - WooCommerce Subscriptions had issues with change of payment method where orders got payment authorized but were not automatically captured and set to complete.

--- a/includes/Functions/order.php
+++ b/includes/Functions/order.php
@@ -6,7 +6,7 @@
  */
 
 use Reepay\Checkout\Utils\TimeKeeper;
-use WC_Reepay_Renewals;
+use WC_Reepay_Renewals as WCRR;
 
 defined( 'ABSPATH' ) || exit();
 
@@ -214,7 +214,7 @@ if ( ! function_exists( 'rp_get_order_by_customer' ) ) {
 				if ( ! empty( $orders ) ) {
 					$order_id = reset( $orders )->get_id();
 					$order    = wc_get_order( $order_id );
-					if ( class_exists( WC_Reepay_Renewals::class ) && WC_Reepay_Renewals::is_order_contain_subscription( $order ) || order_contains_subscription( $order ) ) {
+					if ( class_exists( WCRR::class ) && WCRR::is_order_contain_subscription( $order ) || order_contains_subscription( $order ) ) {
 						$subscription_order = $order;
 					}
 				}

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,7 +4,7 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Billwerk+
  * Author URI: http://billwerk.plus
- * Version: 1.7.7
+ * Version: 1.7.7.1
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0


### PR DESCRIPTION
[Fix] - WP warning message The use statement with non-compound name WC_Reepay_Renewals has no effect.