### PR TITLE
v1.7.8

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -2,9 +2,9 @@
 Contributors: reepaydenmark,aaitse
 Tags: billwerk+, visa, mastercard, dankort, mobilepay
 Requires at least: 4.0
-Tested up to: 6.5.3
+Tested up to: 6.6.1
 Requires PHP: 7.4
-Stable tag: 1.7.7.2
+Stable tag: 1.7.8
 License: GPL
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 
@@ -18,8 +18,14 @@ The Billwerk+ Pay plugin extends WooCommerce allowing you to take payments on yo
 See installation guide right here: https://docu.billwerk.plus/help/en/apps/woocommerce/setup-woocommerce-plugin.html
 
 == Changelog ==
+v 1.7.7.8 -
+- [Fix] - Bug WP warning message "The use statement with non-compound name WC_Reepay_Renewals has no effect." (hotfix 1.7.7.1).
+- [Fix] - Bug double amount calculated when using setting "skip order lines" (hotfix 1.7.7.2).
+- [Fix] - Bug fix WC discount codes on mixed orders.
+- [Improvement] - Extra checkbox in WC standard checkout for subscription conditions.
+
 v 1.7.7.2 -
-* [Fix] - Bug double amount calculated when using setting "skip order lines"
+* [Fix] - Setting skip order lines make calculate amount double.
 
 v 1.7.7.1 -
 * [Fix] - WP warning message The use statement with non-compound name WC_Reepay_Renewals has no effect.

--- a/Readme.txt
+++ b/Readme.txt
@@ -19,10 +19,10 @@ See installation guide right here: https://docu.billwerk.plus/help/en/apps/wooco
 
 == Changelog ==
 v 1.7.7.8 -
-- [Fix] - Bug WP warning message "The use statement with non-compound name WC_Reepay_Renewals has no effect." (hotfix 1.7.7.1).
-- [Fix] - Bug double amount calculated when using setting "skip order lines" (hotfix 1.7.7.2).
-- [Fix] - Bug fix WC discount codes on mixed orders.
-- [Improvement] - Extra checkbox in WC standard checkout for subscription conditions.
+* [Fix] - Bug WP warning message "The use statement with non-compound name WC_Reepay_Renewals has no effect." (hotfix 1.7.7.1).
+* [Fix] - Bug double amount calculated when using setting "skip order lines" (hotfix 1.7.7.2).
+* [Fix] - Bug fix WC discount codes on mixed orders.
+* [Improvement] - Extra checkbox in WC standard checkout for subscription conditions.
 
 v 1.7.7.2 -
 * [Fix] - Setting skip order lines make calculate amount double.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.",
     "type": "wordpress-plugin",
     "license": "GPL",
-    "version": "1.7.7.2",
+    "version": "1.7.8",
     "autoload": {
         "psr-4": {
             "Reepay\\Checkout\\": "includes/",

--- a/includes/Api.php
+++ b/includes/Api.php
@@ -795,6 +795,14 @@ class Api {
 			return new WP_Error( 0, 'Settle has been failed.' );
 		}
 
+		if ( array_key_exists( 'error', $result ) && ! empty( $result['error'] ) ) {
+			return new WP_Error( 0, 'Settle has been failed.' );
+		}
+
+		if ( array_key_exists( 'error_state', $result ) && ! empty( $result['error_state'] ) ) {
+			return new WP_Error( 0, 'Settle has been failed.' );
+		}
+
 		$order->update_meta_data( '_reepay_capture_transaction', $result['transaction'] );
 		$order->save_meta_data();
 

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -10,6 +10,7 @@ namespace Reepay\Checkout\OrderFlow;
 use Exception;
 use Reepay\Checkout\Integrations\PWGiftCardsIntegration;
 use Reepay\Checkout\Integrations\WPCProductBundlesWooCommerceIntegration;
+use Reepay\Checkout\Utils\LoggingTrait;
 use WC_Order;
 use WC_Order_Factory;
 use WC_Order_Item;
@@ -27,6 +28,15 @@ defined( 'ABSPATH' ) || exit();
  * @package Reepay\Checkout\OrderFlow
  */
 class OrderCapture {
+	use LoggingTrait;
+
+	/**
+	 * Debug log for auto settle order capture file name
+	 *
+	 * @var string
+	 */
+	private string $logging_source = 'billwerk_plus_debug_auto_settle_order_capture';
+
 	/**
 	 * Constructor
 	 */
@@ -147,14 +157,55 @@ class OrderCapture {
 	 * @see WC_Order::status_transition
 	 */
 	public function capture_full_order( int $order_id, string $this_status_transition_from, string $this_status_transition_to, WC_Order $order ) {
+
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order_id,
+				'Data'  => array(
+					'$this_status_transition_from' => $this_status_transition_from,
+					'$this_status_transition_to'   => $this_status_transition_to,
+				),
+			)
+		);
+
 		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
 			return;
 		}
 
 		$value = get_transient( 'reepay_order_complete_should_settle_' . $order->get_id() );
 
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order_id,
+				'Data'  => array(
+					'transient_value' => $value,
+				),
+			)
+		);
+
 		if ( 'completed' === $this_status_transition_to && 'no' === reepay()->get_setting( 'disable_auto_settle' ) && ( '1' === $value || false === $value ) ) {
+			$this->log(
+				array(
+					__METHOD__,
+					__LINE__,
+					'order' => $order_id,
+					'msg'   => 'settle order.',
+				)
+			);
 			$this->multi_settle( $order );
+		} else {
+			$this->log(
+				array(
+					__METHOD__,
+					__LINE__,
+					'order' => $order_id,
+					'msg'   => 'can\'t settle order.',
+				)
+			);
 		}
 	}
 
@@ -212,7 +263,27 @@ class OrderCapture {
 		$line_items = array();
 		$total_all  = 0;
 
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order->get_id(),
+			)
+		);
+
 		$invoice_data = reepay()->api( $order )->get_invoice_by_handle( 'order-' . $order->get_id() );
+
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order->get_id(),
+				'data'  => array(
+					'$invoice_data' => $invoice_data,
+				),
+			)
+		);
+
 		if ( is_array( $invoice_data ) && array_key_exists( 'order_lines', $invoice_data ) ) {
 			foreach ( $invoice_data['order_lines'] as $invoice_line ) {
 				$is_exist = false;
@@ -240,21 +311,101 @@ class OrderCapture {
 			}
 		}
 
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order->get_id(),
+				'data'  => array(
+					'$items_data' => $items_data,
+					'$line_items' => $line_items,
+					'$total_all'  => $total_all,
+				),
+			)
+		);
+
 		foreach ( $order->get_items() as $item ) {
+			$this->log(
+				array(
+					__METHOD__,
+					__LINE__,
+					'order' => $order->get_id(),
+					'item'  => $item->get_id(),
+					'data'  => array(
+						'meta_settled' => $item->get_meta( 'settled' ),
+					),
+				)
+			);
+
 			if ( empty( $item->get_meta( 'settled' ) ) ) {
 				$item_data = $this->get_item_data( $item, $order );
 				$price     = self::get_item_price( $item, $order );
 				$total     = rp_prepare_amount( $price['with_tax'], $order->get_currency() );
 
+				$this->log(
+					array(
+						__METHOD__,
+						__LINE__,
+						'order' => $order->get_id(),
+						'item'  => $item->get_id(),
+						'data'  => array(
+							'$item_data' => $item_data,
+							'$price'     => $price,
+							'$total'     => $total,
+						),
+					)
+				);
+
 				if ( $total <= 0 && method_exists( $item, 'get_product' ) && $item->get_product() && wcs_is_subscription_product( $item->get_product() ) ) {
+					$this->log(
+						array(
+							__METHOD__,
+							__LINE__,
+							'order' => $order->get_id(),
+							'item'  => $item->get_id(),
+							'msg'   => 'Condition 1',
+						)
+					);
 					WC_Subscriptions_Manager::activate_subscriptions_for_order( $order );
 				} elseif ( $total > 0 && $this->check_capture_allowed( $order ) ) {
+					$this->log(
+						array(
+							__METHOD__,
+							__LINE__,
+							'order' => $order->get_id(),
+							'item'  => $item->get_id(),
+							'msg'   => 'Condition 2',
+						)
+					);
 					$items_data[] = $item_data;
 					$line_items[] = $item;
 					$total_all   += $total;
+				} else {
+					$this->log(
+						array(
+							__METHOD__,
+							__LINE__,
+							'order' => $order->get_id(),
+							'item'  => $item->get_id(),
+							'msg'   => 'else Condition',
+						)
+					);
 				}
 			}
 		}
+
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order->get_id(),
+				'data'  => array(
+					'$items_data' => $items_data,
+					'$line_items' => $line_items,
+					'$total_all'  => $total_all,
+				),
+			)
+		);
 
 		foreach ( $order->get_items( array( 'shipping', 'fee', PWGiftCardsIntegration::KEY_PW_GIFT_ITEMS ) ) as $item ) {
 			if ( empty( $item->get_meta( 'settled' ) ) ) {
@@ -270,8 +421,30 @@ class OrderCapture {
 			}
 		}
 
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order->get_id(),
+				'data'  => array(
+					'$items_data' => $items_data,
+					'$line_items' => $line_items,
+					'$total_all'  => $total_all,
+				),
+			)
+		);
+
 		if ( ! empty( $items_data ) ) {
-			return $this->settle_items( $order, $items_data, $total_all, $line_items );
+			return $this->settle_items( $order, $items_data, $total_all, $line_items, true );
+		} else {
+			$this->log(
+				array(
+					__METHOD__,
+					__LINE__,
+					'order' => $order->get_id(),
+					'msg'   => 'empty item data',
+				)
+			);
 		}
 
 		return false;
@@ -291,7 +464,32 @@ class OrderCapture {
 	public function settle_items( WC_Order $order, array $items_data, float $total_all, array $line_items, bool $instant_note = true ): bool {
 		unset( $_POST['post_status'] ); // // Prevent order status changing by WooCommerce
 
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order->get_id(),
+				'data'  => array(
+					'$items_data'   => $items_data,
+					'$line_items'   => $line_items,
+					'$total_all'    => $total_all,
+					'$instant_note' => $instant_note,
+				),
+			)
+		);
+
 		$result = reepay()->api( $order )->settle( $order, $total_all, $items_data, $line_items, $instant_note );
+
+		$this->log(
+			array(
+				__METHOD__,
+				__LINE__,
+				'order' => $order->get_id(),
+				'data'  => array(
+					'$result' => $result,
+				),
+			)
+		);
 
 		if ( is_wp_error( $result ) ) {
 			rp_get_payment_method( $order )->log( sprintf( '%s Error: %s', __METHOD__, $result->get_error_message() ) );

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,11 +4,11 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Billwerk+
  * Author URI: http://billwerk.plus
- * Version: 1.7.7.2
+ * Version: 1.7.8
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0
- * WC tested up to: 7.5.0
+ * WC tested up to: 9.1.4
  *
  * @package Reepay\Checkout
  */


### PR DESCRIPTION
[Fix] - Bug WP warning message "The use statement with non-compound name WC_Reepay_Renewals has no effect." (hotfix 1.7.7.1).
[Fix] - Bug double amount calculated when using setting "skip order lines" (hotfix 1.7.7.2).
[Fix] - Bug fix WC discount codes on mixed orders.
[Improvement] - Extra checkbox in WC standard checkout for subscription conditions.