### PR TITLE
v1.7.8.1

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -4,7 +4,7 @@ Tags: billwerk+, visa, mastercard, dankort, mobilepay
 Requires at least: 4.0
 Tested up to: 6.6.1
 Requires PHP: 7.4
-Stable tag: 1.7.8
+Stable tag: 1.7.8.1
 License: GPL
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 
@@ -18,6 +18,9 @@ The Billwerk+ Pay plugin extends WooCommerce allowing you to take payments on yo
 See installation guide right here: https://docu.billwerk.plus/help/en/apps/woocommerce/setup-woocommerce-plugin.html
 
 == Changelog ==
+v 1.7.8.1 - 
+* [Fix] - Fixed total calculation missing multiplication with number of items when using setting "Skip order lines" 
+
 v 1.7.8 -
 * [Fix] - Bug WP warning message "The use statement with non-compound name WC_Reepay_Renewals has no effect." (hotfix 1.7.7.1).
 * [Fix] - Bug double amount calculated when using setting "skip order lines" (hotfix 1.7.7.2).

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -1397,11 +1397,11 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 	 *
 	 * @param WC_Order $order            order to get items.
 	 * @param bool     $only_not_settled get only not settled items.
-	 * @param bool     $skipt_order_line get item price without calculate quantity.
+	 * @param bool     $skip_order_line get item price without calculate quantity.
 	 *
 	 * @return array
 	 */
-	public function get_order_items( WC_Order $order, bool $only_not_settled = false, $skipt_order_line = false ): array {
+	public function get_order_items( WC_Order $order, bool $only_not_settled = false, $skip_order_line = false ): array {
 		$prices_incl_tax = wc_prices_include_tax();
 
 		$items               = array();
@@ -1430,7 +1430,11 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 			$price       = OrderCapture::get_item_price( $order_item, $order );
 			$tax_percent = $price['tax_percent'];
 
-			if ( $skipt_order_line ) {
+			if ( $tax_percent > 0 ) {
+				$prices_incl_tax = true;
+			}
+
+			if ( $skip_order_line ) {
 				$unit_price = round( ( $prices_incl_tax ? $price['subtotal_with_tax'] : $price['subtotal'] ), 2 );
 			} else {
 				$unit_price = round( ( $prices_incl_tax ? $price['subtotal_with_tax'] : $price['subtotal'] ) / $order_item->get_quantity(), 2 );

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -1400,7 +1400,7 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 	 *
 	 * @return array
 	 */
-	public function get_order_items( WC_Order $order, bool $only_not_settled = false ): array {
+	public function get_order_items( WC_Order $order, bool $only_not_settled = false, $skipt_order_line = false ): array {
 		$prices_incl_tax = wc_prices_include_tax();
 
 		$items               = array();
@@ -1429,7 +1429,11 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 			$price       = OrderCapture::get_item_price( $order_item, $order );
 			$tax_percent = $price['tax_percent'];
 
-			$unit_price = round( ( $prices_incl_tax ? $price['subtotal_with_tax'] : $price['subtotal'] ) / $order_item->get_quantity(), 2 );
+			if($skipt_order_line){
+				$unit_price = round( ( $prices_incl_tax ? $price['subtotal_with_tax'] : $price['subtotal'] ), 2 );
+			}else{
+				$unit_price = round( ( $prices_incl_tax ? $price['subtotal_with_tax'] : $price['subtotal'] ) / $order_item->get_quantity(), 2 );
+			}
 
 			if ( $only_not_settled && ! empty( $order_item->get_meta( 'settled' ) ) ) {
 				continue;
@@ -1568,7 +1572,7 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 	public function get_skip_order_lines_amount( WC_Order $order ) {
 		$total_amount = 0;
 
-		$items = $this->get_order_items( $order );
+		$items = $this->get_order_items( $order, false, true );
 
 		if ( $items ) {
 			foreach ( $items as $item ) {

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -1397,6 +1397,7 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 	 *
 	 * @param WC_Order $order            order to get items.
 	 * @param bool     $only_not_settled get only not settled items.
+	 * @param bool     $skipt_order_line get item price without calculate quantity.
 	 *
 	 * @return array
 	 */
@@ -1429,9 +1430,9 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 			$price       = OrderCapture::get_item_price( $order_item, $order );
 			$tax_percent = $price['tax_percent'];
 
-			if($skipt_order_line){
+			if ( $skipt_order_line ) {
 				$unit_price = round( ( $prices_incl_tax ? $price['subtotal_with_tax'] : $price['subtotal'] ), 2 );
-			}else{
+			} else {
 				$unit_price = round( ( $prices_incl_tax ? $price['subtotal_with_tax'] : $price['subtotal'] ) / $order_item->get_quantity(), 2 );
 			}
 

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,7 +4,7 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Billwerk+
  * Author URI: http://billwerk.plus
- * Version: 1.7.8
+ * Version: 1.7.8.1
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0


### PR DESCRIPTION
Fixed total calculation missing multiplication with number of items when using setting "Skip order lines" 