### PR TITLE
v 1.7.9.2

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -4,7 +4,7 @@ Tags: billwerk+, visa, mastercard, dankort, mobilepay
 Requires at least: 4.0
 Tested up to: 6.6.1
 Requires PHP: 7.4
-Stable tag: 1.7.9.1
+Stable tag: 1.7.9.2
 License: GPL
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 
@@ -18,6 +18,11 @@ The Billwerk+ Pay plugin extends WooCommerce allowing you to take payments on yo
 See installation guide right here: https://docu.billwerk.plus/help/en/apps/woocommerce/setup-woocommerce-plugin.html
 
 == Changelog ==
+v 1.7.9.2
+- [Fix] - WebHook URL for plain permalink structure
+- [Fix] - Remove debug log is make notice message on cart page.
+- [Fix] - Since v1.7.9.1, setting "skip order lines" caused the authorized amount to be multiplied by 100 one more time. Only when using saved card to pay.
+
 v 1.7.9.1
 - [Fix] – The payment method 'Vipps MobilePay Recurring' did not save the token.
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.",
     "type": "wordpress-plugin",
     "license": "GPL",
-    "version": "1.7.9.1",
+    "version": "1.7.9.2",
     "autoload": {
         "psr-4": {
             "Reepay\\Checkout\\": "includes/",

--- a/includes/Api.php
+++ b/includes/Api.php
@@ -1096,13 +1096,6 @@ class Api {
 
 		$result = $tmp;
 
-		wc_get_logger()->debug(
-			array(
-				'source'  => 'billwerk-token',
-				'_legacy' => true,
-			)
-		);
-
 		if ( ! $reepay_token ) {
 			return $result['cards'];
 		}

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -1006,7 +1006,7 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 					return $this->process_session_charge( $params, $order );
 				} else {
 					$order_lines = 'no' === $this->skip_order_lines ? $this->get_order_items( $order ) : null;
-					$amount      = 'yes' === $this->skip_order_lines ? $this->get_skip_order_lines_amount( $order ) : null;
+					$amount      = 'yes' === $this->skip_order_lines ? $this->get_skip_order_lines_amount( $order, true ) : null;
 
 					// Charge payment.
 					$result = reepay()->api( $this )->charge( $order, $token->get_token(), $amount, $order_lines );
@@ -1582,8 +1582,9 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 	 * Get order amount from order item amount
 	 *
 	 * @param WC_Order $order            order to get items.
+	 * @param bool     $skip_fn_rp_amount        skip call funcion rp_prepare_amount.
 	 */
-	public function get_skip_order_lines_amount( WC_Order $order ) {
+	public function get_skip_order_lines_amount( WC_Order $order, $skip_fn_rp_amount = false ) {
 		$total_amount = 0;
 
 		if ( wcs_cart_have_subscription() ) {
@@ -1593,6 +1594,8 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 					$total_amount += $item['amount'];
 				}
 			}
+		} elseif ( true === $skip_fn_rp_amount ) {
+				$total_amount = $order->get_total();
 		} else {
 			$total_amount = rp_prepare_amount( $order->get_total(), $order->get_currency() );
 		}

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -431,12 +431,12 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 		}
 
 		$structure = get_option( 'permalink_structure' );
-		if( empty( $structure ) ){
+		if ( empty( $structure ) ) {
 			$default_wc_api_url = $default_wc_api_url . '=WC_Gateway_Reepay/';
-		}else{
+		} else {
 			$default_wc_api_url = $default_wc_api_url . 'WC_Gateway_Reepay/';
 		}
-		
+
 		return $default_wc_api_url;
 	}
 

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -430,7 +430,14 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 			}
 		}
 
-		return $default_wc_api_url . 'WC_Gateway_Reepay/';
+		$structure = get_option( 'permalink_structure' );
+		if( empty( $structure ) ){
+			$default_wc_api_url = $default_wc_api_url . '=WC_Gateway_Reepay/';
+		}else{
+			$default_wc_api_url = $default_wc_api_url . 'WC_Gateway_Reepay/';
+		}
+		
+		return $default_wc_api_url;
 	}
 
 	/**

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,7 +4,7 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Billwerk+
  * Author URI: http://billwerk.plus
- * Version: 1.7.9.1
+ * Version: 1.7.9.2
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0


### PR DESCRIPTION
[Fix] - WebHook URL for plain permalink structure
[Fix] - Remove debug log is make notice message on cart page.
[Fix] - Since v1.7.9.1, setting "skip order lines" caused the authorized amount to be multiplied by 100 one more time. Only when using saved card to pay.