### PR TITLE
v 1.7.15

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -18,6 +18,13 @@ The Billwerk+ Pay plugin extends WooCommerce allowing you to take payments on yo
 See installation guide right here: https://docu.billwerk.plus/help/en/apps/woocommerce/setup-woocommerce-plugin.html
 
 == Changelog ==
+v 1.7.15
+- [Fix] - Support for WordPress posts storage (legacy) as WooCommerce Order data storage setting.
+- [Fix] - Warning message if High Performance Order Storage is disabled or unavailable is changed to a notice.
+- [Fix] - Sends same order lines for authorize and capture to fix rounding differences in totals with discounts and price input exclusive tax.
+- [Improvement] - Adds feature to specify other amount to capture.
+- [Improvement] - Support for card type emv_token.
+
 v 1.7.14
 - [Fix] - Polylang support PHP session usage changed to cookie.
 - [Improvement] - Warning message if High Performance Order Storage is disabled or unavailable.

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -43,19 +43,30 @@
                         color: red;
                     }
                 }
-            }
-
-            &-header {
-                width: 100%;
-                font-weight: bold;
-
-                &-small {
+                &-header {
                     width: 100%;
                     font-weight: bold;
-                    font-size: small;
-                    margin-bottom: 0;
+    
+                    &-small {
+                        width: 100%;
+                        font-weight: bold;
+                        font-size: small;
+                        margin-bottom: 0;
+                    }
+                }
+
+                .capture-amount-button{
+                    width: 100%;
                 }
             }
+
+            .capture-amount-input{
+                width: 80%;
+                font-size: 11px;
+                height: 20px;
+                min-height: unset;
+            }
+    
         }
     }
 
@@ -102,6 +113,16 @@
         display: -ms-flexbox;
         display: -webkit-flex;
         display: flex;
+    }
+    
+    &__capture-amount{
+        display: inline-flex;
+        align-items: center;
+    }
+
+    &__capture-amount-input{
+        display: inline-flex;
+        align-items: center;
     }
 }
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -218,4 +218,46 @@ jQuery(document).ready(function ($) {
         alias: "currency",
         groupSeparator: ''
     })
+    
+    $(document).on('click', '#reepay-capture-amount-button', function (e) {
+        e.preventDefault();
+
+        let $form = $('#post')
+        if ($form.length === 0) {
+            $form = $('#order')
+        }
+        const capture_amount = $('#reepay-capture-amount-input').val()
+        const amount = $('#reepay_order_total').data('order-total')
+        const $inputSettled = $('#reepay_order_total_settled')
+        const initialSettled = $inputSettled.data('initial-amount')
+        const currency = $('#reepay_currency').val()
+        const formatted_amount = Number((parseFloat(amount) - parseFloat(initialSettled)).toFixed(2))
+
+        if (capture_amount > formatted_amount) {
+            alert(`'The capture amount must be less than or equal to ${formatted_amount} ${currency}'`)
+            return
+        }
+
+        const settle = window.confirm(`'Do you want to capture the amount ${capture_amount} ${currency}? Click OK to continue with settle. Click Cancel to continue without settle.'`)
+
+        if (settle) {
+            const $button = $(this);
+
+            $form.one('submit', function() {
+                const buttonName = $button.attr('name')
+                const buttonValue = $button.val()
+                
+                if (buttonName && buttonValue) {
+                    $('<input>').attr({
+                        type: 'hidden',
+                        name: buttonName,
+                        value: buttonValue
+                    }).appendTo(this);
+                }
+            });
+            
+            $form.submit()
+        }
+    });
+    
 })

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.",
     "type": "wordpress-plugin",
     "license": "GPL",
-    "version": "1.7.14",
+    "version": "1.7.15",
     "autoload": {
         "psr-4": {
             "Reepay\\Checkout\\": "includes/",

--- a/includes/Actions/Admin.php
+++ b/includes/Actions/Admin.php
@@ -61,10 +61,14 @@ class Admin {
 			return;
 		}
 
+		if ( 'woocommerce_page_wc-settings' !== get_current_screen()->id ) {
+			return;
+		}
+
 		// Check WooCommerce version.
 		if ( version_compare( WC()->version, '7.1', '<' ) ) {
 			echo '<div class="notice notice-error"><p>' .
-				__( 'Critical Error: Billwerk+ require High Performance Order Storage. You must update WooCommerce to at least version 7.1 to have this feature.', 'reepay-checkout-gateway' ) .
+				__( 'Billwerk+ works best with High Performance Order Storage. You must update WooCommerce to at least version 7.1 to have this feature.', 'reepay-checkout-gateway' ) .
 				'</p></div>';
 			return;
 		}
@@ -73,7 +77,7 @@ class Admin {
 		$hpos_enabled = 'yes' === get_option( 'woocommerce_custom_orders_table_enabled', 'no' );
 		if ( ! $hpos_enabled ) {
 			echo '<div class="notice notice-error"><p>' .
-				__( 'Critical Error: Billwerk+ require High Performance Order Storage. You must activate it in the WooCommerce settings under the "Advanced" tab, "Features" sub-tab.', 'reepay-checkout-gateway' ) .
+				__( 'Billwerk+ works best with High Performance Order Storage. You can activate it in the WooCommerce settings under the "Advanced" tab, "Features" sub-tab.', 'reepay-checkout-gateway' ) .
 				'</p></div>';
 		}
 	}

--- a/includes/Api.php
+++ b/includes/Api.php
@@ -1077,7 +1077,7 @@ class Api {
 		);
 		if ( $result['count'] > 0 ) {
 			foreach ( $result['content'] as $payment_method ) {
-				if ( 'card' === $payment_method['payment_type'] ) {
+				if ( in_array( $payment_method['payment_type'], array( 'card', 'emv_token' ), true ) ) {
 					$card = $payment_method;
 					$card = array_merge( $card, $payment_method['card'] );
 					unset( $card['card'], $card['gateway'], $card['card_agreement'], $card['payment_type'] );

--- a/includes/Api.php
+++ b/includes/Api.php
@@ -724,6 +724,8 @@ class Api {
 
 		if ( ! empty( $amount ) && reepay()->get_setting( 'skip_order_lines' ) === 'yes' ) {
 			$request_data['amount'] = $amount;
+		} elseif ( ! empty( $amount ) && false === $line_item ) {
+			$request_data['amount'] = $amount;
 		} else {
 			$request_data['order_lines'] = $items_data;
 		}
@@ -779,7 +781,7 @@ class Api {
 			$error = sprintf(
 				// translators: %1$s amount, %2$s error message.
 				__( 'Failed to settle %1$s. Error: %2$s.', 'reepay-checkout-gateway' ),
-				$items_data ? floatval( $items_data[0]['amount'] ) / 100 : $amount,
+				$items_data ? floatval( $items_data[0]['amount'] ) / 100 : floatval( $amount ) / 100,
 				$result->get_error_message()
 			);
 

--- a/includes/Functions/order.php
+++ b/includes/Functions/order.php
@@ -97,22 +97,39 @@ if ( ! function_exists( 'rp_get_not_subs_order_by_handle' ) ) {
 	 */
 	function rp_get_not_subs_order_by_handle( string $handle ) {
 
-		$orders = wc_get_orders(
-			array(
-				'limit'      => 1,
-				'meta_query' => array( //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					array(
-						'key'   => '_reepay_order',
-						'value' => $handle,
-					),
-					array(
-						'key'     => '_reepay_is_subscription',
-						'compare' => 'NOT EXISTS',
-					),
+		if ( rp_hpos_enabled() ) {
+			$orders = wc_get_orders(
+				array(
+					'limit'      => 1,
+					'meta_query' => array( //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						array(
+							'key'   => '_reepay_order',
+							'value' => $handle,
+						),
+						array(
+							'key'     => '_reepay_is_subscription',
+							'compare' => 'NOT EXISTS',
+						),
 
-				),
-			)
-		);
+					),
+				)
+			);
+		} else {
+			$orders = wc_get_orders(
+				array(
+					'limit'        => 1,
+					'meta_key'     => '_reepay_order', //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_value'   => $handle, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+					'meta_compare' => '=',
+					'meta_query'   => array( //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						array(
+							'key'     => '_reepay_is_subscription',
+							'compare' => 'NOT EXISTS',
+						),
+					),
+				)
+			);
+		}
 
 		if ( ! empty( $orders ) ) {
 			$order_id = reset( $orders )->get_id();
@@ -198,18 +215,29 @@ if ( ! function_exists( 'rp_get_order_by_customer' ) ) {
 			$search_string = strpos( $content['handle'], 'order-' );
 			if ( false !== $search_string ) {
 				$handle = $content['handle'];
-				$orders = wc_get_orders(
-					array(
-						'limit'      => 1,
-						'meta_query' => array( //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-							array(
-								'key'   => '_reepay_order',
-								'value' => $handle,
-							),
+				if ( rp_hpos_enabled() ) {
+					$orders = wc_get_orders(
+						array(
+							'limit'      => 1,
+							'meta_query' => array( //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+								array(
+									'key'   => '_reepay_order',
+									'value' => $handle,
+								),
 
-						),
-					)
-				);
+							),
+						)
+					);
+				} else {
+					$orders = wc_get_orders(
+						array(
+							'limit'        => 1,
+							'meta_key'     => '_reepay_order', //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+							'meta_value'   => $handle, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value	
+							'meta_compare' => '=',
+						)
+					);
+				}
 
 				if ( ! empty( $orders ) ) {
 					$order_id = reset( $orders )->get_id();

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -1515,7 +1515,7 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 			$tax               = $discount_with_tax - $discount;
 			$tax_percent       = ( $tax > 0 ) ? round( 100 / ( $discount / $tax ) ) : 0;
 
-			if ( 0 !== $sub_amount_discount && 0 !== $discount ) {
+			if ( abs( floatval( $sub_amount_discount ) ) > 0.001 && abs( floatval( $discount ) ) > 0.001 ) {
 				/**
 				 * Discount for subscription
 				 */

--- a/includes/OrderFlow/InstantSettle.php
+++ b/includes/OrderFlow/InstantSettle.php
@@ -148,6 +148,10 @@ class InstantSettle {
 				$total_all   += $total;
 			}
 
+			if ( reepay()->get_setting( 'skip_order_lines' ) === 'yes' ) {
+				$total_all = rp_prepare_amount( $order->get_total(), $order->get_currency() );
+			}
+
 			self::$order_capture->settle_items( $order, $items_data, $total_all, $settle_items );
 
 			$order->add_meta_data( '_is_instant_settled', '1' );

--- a/includes/OrderFlow/InstantSettle.php
+++ b/includes/OrderFlow/InstantSettle.php
@@ -108,6 +108,38 @@ class InstantSettle {
 				}
 			}
 
+			// Add discount line.
+			if ( $order->get_total_discount( false ) > 0 ) {
+				$prices_incl_tax   = wc_prices_include_tax();
+				$discount          = $order->get_total_discount();
+				$discount_with_tax = $order->get_total_discount( false );
+				$tax               = $discount_with_tax - $discount;
+				$tax_percent       = ( $tax > 0 ) ? round( 100 / ( $discount / $tax ) ) : 0;
+
+				if ( $prices_incl_tax ) {
+					/**
+					 * Discount for simple product included tax
+					 */
+					$simple_discount_amount = $discount_with_tax;
+				} else {
+					$simple_discount_amount = $discount;
+				}
+
+				$discount_amount = round( - 1 * rp_prepare_amount( $simple_discount_amount, $order->get_currency() ) );
+
+				if ( $discount_amount < 0 ) {
+					$items_discount = array(
+						'ordertext'       => __( 'Discount', 'reepay-checkout-gateway' ),
+						'quantity'        => 1,
+						'amount'          => round( $discount_amount, 2 ),
+						'vat'             => round( $tax_percent / 100, 2 ),
+						'amount_incl_vat' => $prices_incl_tax,
+					);
+					$items_data[]   = $items_discount;
+					$total_all     += $discount_amount;
+				}
+			}
+
 			foreach ( $order->get_items( WCGiftCardsIntegration::KEY_WC_GIFT_ITEMS ) as $item ) {
 				$item_data    = self::$order_capture->get_item_data( $item, $order );
 				$price        = $item->get_amount() * - 1;

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -20,6 +20,7 @@ use WC_Product;
 use WC_Reepay_Renewals;
 use WC_Subscriptions_Manager;
 use WC_Order_Item_Fee;
+use WP_Error;
 
 defined( 'ABSPATH' ) || exit();
 
@@ -51,6 +52,8 @@ class OrderCapture {
 		add_action( 'woocommerce_order_status_changed', array( $this, 'capture_full_order' ), 10, 4 );
 
 		add_action( 'admin_init', array( $this, 'process_item_capture' ) );
+
+		add_action( 'admin_init', array( $this, 'process_capture_amount' ) );
 
 		add_action( 'woocommerce_order_item_add_action_buttons', array( $this, 'capture_full_order_button' ), 10, 1 );
 
@@ -110,7 +113,8 @@ class OrderCapture {
 			empty( $item->get_meta( 'settled' ) ) &&
 			floatval( $item->get_data()['total'] ) > 0 &&
 			$this->check_capture_allowed( $order ) &&
-			! WCGiftCardsIntegration::check_order_have_wc_giftcard( $order )
+			! WCGiftCardsIntegration::check_order_have_wc_giftcard( $order ) &&
+			empty( $order->get_meta( '_reepay_remaining_balance' ) )
 		) {
 			$price = self::get_item_price( $item, $order );
 
@@ -133,7 +137,7 @@ class OrderCapture {
 	public function capture_full_order_button( WC_Order $order ) {
 		$amount = $this->get_not_settled_amount( $order );
 
-		if ( $amount <= 0 || ! $this->check_capture_allowed( $order ) ) {
+		if ( $amount <= 0 || ! $this->check_capture_allowed( $order ) || ! empty( $order->get_meta( '_reepay_remaining_balance' ) ) ) {
 			return;
 		}
 
@@ -240,6 +244,42 @@ class OrderCapture {
 			$this->settle_item( WC_Order_Factory::get_order_item( $_POST['line_item_capture'] ), $order );
 		} elseif ( isset( $_POST['all_items_capture'] ) ) {
 			$this->multi_settle( $order );
+		}
+	}
+
+	/**
+	 * Hooked to admin_init. Capture specified amount from request
+	 */
+	public function process_capture_amount() {
+		if ( rp_hpos_enabled() ) {
+			if ( ! rp_hpos_is_order_page() ) {
+				return;
+			}
+		} elseif ( ! isset( $_POST['post_type'] ) ||
+				'shop_order' !== $_POST['post_type'] ||
+				! isset( $_POST['post_ID'] ) ) {
+
+				return;
+		}
+
+		if ( ! isset( $_POST['reepay_capture_amount_button'] ) && ! isset( $_POST['reepay_capture_amount_input'] ) ) {
+			return;
+		}
+
+		if ( 'process_capture_amount' !== $_POST['reepay_capture_amount_button'] ) {
+			return;
+		}
+
+		$reepay_capture_amount_input = wc_format_decimal( $_POST['reepay_capture_amount_input'] );
+
+		$order = wc_get_order( $_POST['post_ID'] );
+
+		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
+			return;
+		}
+
+		if ( isset( $_POST['reepay_capture_amount_input'] ) ) {
+			$this->settle_amount( $order, $reepay_capture_amount_input );
 		}
 	}
 
@@ -593,6 +633,51 @@ class OrderCapture {
 		}
 
 		$this->complete_settle( $item, $order, $total );
+
+		return true;
+	}
+
+	/**
+	 * Settle specified amount
+	 *
+	 * @param WC_Order $order order to settle.
+	 * @param float    $amount amount to settle.
+	 *
+	 * @return bool
+	 */
+	public function settle_amount( WC_Order $order, float $amount ): bool {
+		unset( $_POST['post_status'] ); // Prevent order status changing by WooCommerce.
+
+		if ( $amount <= 0 ) {
+			return false;
+		}
+
+		if ( ! $this->check_capture_allowed( $order ) ) {
+			return false;
+		}
+
+		$amount = rp_prepare_amount( $amount, $order->get_currency() );
+
+		$result = reepay()->api( $order )->settle( $order, $amount, false, false );
+
+		if ( is_wp_error( $result ) ) {
+			rp_get_payment_method( $order )->log( sprintf( '%s Error: %s', __METHOD__, $result->get_error_message() ) );
+			set_transient( 'reepay_api_action_error', $result->get_error_message(), MINUTE_IN_SECONDS / 2 );
+
+			return false;
+		}
+
+		if ( 'failed' === $result['state'] ) {
+			set_transient( 'reepay_api_action_error', __( 'Failed to settle amount', 'reepay-checkout-gateway' ), MINUTE_IN_SECONDS / 2 );
+
+			return false;
+		}
+
+		$remaining_balance = $result['authorized_amount'] - $result['amount'];
+
+		$order->update_meta_data( '_reepay_remaining_balance', $remaining_balance );
+		$order->save_meta_data();
+		$order->save();
 
 		return true;
 	}

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -451,6 +451,38 @@ class OrderCapture {
 			)
 		);
 
+		// Add discount line.
+		if ( $order->get_total_discount( false ) > 0 ) {
+			$prices_incl_tax   = wc_prices_include_tax();
+			$discount          = $order->get_total_discount();
+			$discount_with_tax = $order->get_total_discount( false );
+			$tax               = $discount_with_tax - $discount;
+			$tax_percent       = ( $tax > 0 ) ? round( 100 / ( $discount / $tax ) ) : 0;
+
+			if ( $prices_incl_tax ) {
+				/**
+				 * Discount for simple product included tax
+				 */
+				$simple_discount_amount = $discount_with_tax;
+			} else {
+				$simple_discount_amount = $discount;
+			}
+
+			$discount_amount = round( - 1 * rp_prepare_amount( $simple_discount_amount, $order->get_currency() ) );
+
+			if ( $discount_amount < 0 ) {
+				$items_discount = array(
+					'ordertext'       => __( 'Discount', 'reepay-checkout-gateway' ),
+					'quantity'        => 1,
+					'amount'          => round( $discount_amount, 2 ),
+					'vat'             => round( $tax_percent / 100, 2 ),
+					'amount_incl_vat' => $prices_incl_tax,
+				);
+				$items_data[]   = $items_discount;
+				$total_all     += $discount_amount;
+			}
+		}
+
 		foreach ( $order->get_items( array( 'shipping', 'fee', PWGiftCardsIntegration::KEY_PW_GIFT_ITEMS ) ) as $item ) {
 			if ( empty( $item->get_meta( 'settled' ) ) ) {
 				$item_data = $this->get_item_data( $item, $order );
@@ -617,6 +649,11 @@ class OrderCapture {
 			return false;
 		}
 
+		if ( $price['subtotal'] > $price['original'] ) {
+			$unit_price          = round( $price['original'] / $item->get_quantity(), 2 );
+			$item_data['amount'] = rp_prepare_amount( $unit_price, $order->get_currency() );
+		}
+
 		$result = reepay()->api( $order )->settle( $order, $total, array( $item_data ), $item );
 
 		if ( is_wp_error( $result ) ) {
@@ -747,8 +784,12 @@ class OrderCapture {
 			$unit_price = WCGiftCardsIntegration::get_negative_amount_from_order_item( $order, $order_item );
 			$ordertext  = WCGiftCardsIntegration::get_name_from_order_item( $order, $order_item );
 		} else {
-			$unit_price = round( ( $prices_incl_tax ? $price['with_tax'] : $price['original'] ) / $order_item->get_quantity(), 2 );
-			$ordertext  = rp_clear_ordertext( $order_item->get_name() );
+			if ( $order->get_total_discount( false ) > 0 ) {
+				$unit_price = round( ( $prices_incl_tax ? $price['with_tax'] : $price['subtotal'] ) / $order_item->get_quantity(), 2 );
+			} else {
+				$unit_price = round( ( $prices_incl_tax ? $price['with_tax'] : $price['original'] ) / $order_item->get_quantity(), 2 );
+			}
+			$ordertext = rp_clear_ordertext( $order_item->get_name() );
 		}
 
 		return array(

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -506,6 +506,10 @@ class OrderCapture {
 			$total_all   += $total;
 		}
 
+		if ( reepay()->get_setting( 'skip_order_lines' ) === 'yes' ) {
+			$total_all = rp_prepare_amount( $order->get_total(), $order->get_currency() );
+		}
+
 		$this->log(
 			array(
 				__METHOD__,

--- a/includes/Utils/MetaField.php
+++ b/includes/Utils/MetaField.php
@@ -47,7 +47,7 @@ class MetaField {
 		'_reepay_membership_id',
 		'_payment_method_id',
 		'_real_total',
-
+		'_reepay_remaining_balance',
 		// user fields.
 		'reepay_customer_id',
 	);

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,7 +4,7 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Billwerk+
  * Author URI: http://billwerk.plus
- * Version: 1.7.14
+ * Version: 1.7.15
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0

--- a/templates/meta-boxes/invoice.php
+++ b/templates/meta-boxes/invoice.php
@@ -112,6 +112,27 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 			<?php echo rp_make_initial_amount( $order_data['refunded_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ); ?>
 		</span>
 	</li>
+	<?php
+	$capture_amount = $order_data['authorized_amount'] ? rp_make_initial_amount( $order_data['authorized_amount'] - $order_data['settled_amount'], $order_data['currency'] ) : $order_data['authorized_amount'];
+	if ( $capture_amount > 0 ) {
+		$capture_amount_format = $capture_amount;
+		?>
+		<li class="reepay-admin-section-li">
+			<span class="reepay-balance__label reepay-balance__capture-amount">
+				<?php echo esc_html__( 'Capture amount', 'reepay-checkout-gateway' ); ?>:
+			</span>
+			<span class="reepay-balance__amount reepay-balance__capture-amount-input">
+				<input type="text" id="reepay-capture-amount-input" name="reepay_capture_amount_input" class="capture-amount-input" value="<?php echo $capture_amount_format; ?>" />&nbsp;&nbsp;<?php echo get_woocommerce_currency_symbol( $order->get_currency() ); ?>
+			</span>
+		</li>
+		<li class="reepay-admin-section-li-small">
+			<button type="submit" class="button capture-amount-button" id="reepay-capture-amount-button" name="reepay_capture_amount_button" value="process_capture_amount">
+				<?php echo esc_html__( 'Capture Specified Amount', 'reepay-checkout-gateway' ); ?>
+			</button>
+		</li>
+		<?php
+	}
+	?>
 
 	<li class="reepay-admin-section-li-small" style="margin-top: 15px;">
 		<a class="button" href="<?php echo $link; ?>" target="_blank">


### PR DESCRIPTION
- [Fix] - Support for WordPress posts storage (legacy) as WooCommerce Order data storage setting.
- [Fix] - Warning message if High Performance Order Storage is disabled or unavailable is changed to a notice.
- [Fix] - Sends same order lines for authorize and capture to fix rounding differences in totals with discounts and price input exclusive tax.
- [Improvement] - Adds feature to specify other amount to capture.
- [Improvement] - Support for card type emv_token.