### PR TITLE
v 1.8.3

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -4,7 +4,7 @@ Tags: Frisbii, billwerk+, visa, mastercard, dankort, mobilepay
 Requires at least: 4.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.8.2.1
+Stable tag: 1.8.3
 License: GPL
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 
@@ -18,6 +18,12 @@ The Frisbii Pay plugin extends WooCommerce allowing you to take payments on your
 See installation guide right here: https://docu.billwerk.plus/help/en/apps/woocommerce/setup-woocommerce-plugin.html
 
 == Changelog ==
+v 1.8.3
+- [FIX] - In case Frisbii process a renewal successfully for a subscriptionorder that is marked as Completed in WooCommerce then the order note will not say the settlement failed and the invoice wasn't found.
+- [Fix] - Replaces calls to buggy sync_order API endpoint in WooCommerce 10.1.0.
+- [Fix] - An order note "Payment has been settled" was missing when capturing all items for orders containing bundle products.
+- [Fix] - The order is updated with any surcharge fees when charged.
+
 v 1.8.2.1
 - [Fix] - User privilege escalation vulnerability.
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.",
     "type": "wordpress-plugin",
     "license": "GPL",
-    "version": "1.8.2.1",
+    "version": "1.8.3",
     "autoload": {
         "psr-4": {
             "Reepay\\Checkout\\": "includes/",

--- a/includes/Analytics/AnalyticsSync.php
+++ b/includes/Analytics/AnalyticsSync.php
@@ -71,9 +71,8 @@ class AnalyticsSync {
 	private function force_analytics_sync( $order_id ) {
 		// Trigger the WooCommerce update hook.
 		do_action( 'woocommerce_update_order', $order_id );
-		//do_action( 'woocommerce_analytics_update_order_stats', $order_id );
-    
-		// Trigger order save to ensure analytics are updated
+
+		// Trigger order save to ensure analytics are updated.
 		$order = wc_get_order( $order_id );
 		if ( $order ) {
 			$order->save();

--- a/includes/Api.php
+++ b/includes/Api.php
@@ -814,8 +814,8 @@ class Api {
 				}
 			}
 
-			// Skip add order note process if error code is 31 (Invoice not found)
-			if ($result->get_error_code() == 31 ) {
+			// Skip add order note process if error code is 31 (Invoice not found).
+			if ( $result->get_error_code() === 31 ) {
 				return $result;
 			}
 

--- a/includes/Api.php
+++ b/includes/Api.php
@@ -703,8 +703,7 @@ class Api {
 	 * @ToDO refactor function. $amount is useless.
 	 */
 	public function settle( WC_Order $order, $amount = null, $items_data = false, $line_item = false, bool $instant_note = true ) {
-		$this->log( sprintf( 'Settle: %s, %s', $order->get_id(), $amount ) );
-		$this->log( sprintf( 'Settle Instant note: %s', $instant_note ? 'true' : 'false' ) );
+		$this->log( sprintf( 'Settle: %s, Amount: %s', $order->get_id(), $amount ) );
 
 		$handle = rp_get_order_handle( $order );
 		if ( empty( $handle ) ) {

--- a/includes/Api.php
+++ b/includes/Api.php
@@ -760,7 +760,7 @@ class Api {
 						$request_data
 					);
 
-					// Add success order note if the retry was successful
+					// Add success order note if the retry was successful.
 					if ( ! is_wp_error( $retry_result ) && ! empty( $retry_result['transaction'] ) ) {
 						$message = sprintf(
 							// translators: %1$s amount to settle, %2$s transaction number.
@@ -792,7 +792,7 @@ class Api {
 								$request_data
 							);
 
-							// Add success order note if the retry was successful
+							// Add success order note if the retry was successful.
 							if ( ! is_wp_error( $retry_result ) && ! empty( $retry_result['transaction'] ) ) {
 								$message = sprintf(
 									// translators: %1$s amount to settle, %2$s transaction number.

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -393,6 +393,7 @@ class OrderCapture {
 
 			// Skip bundle products to be consistent with other methods.
 			if ( WPCProductBundlesWooCommerceIntegration::is_order_item_bundle( $item ) ) {
+				$item_data = $this->get_item_data( $item, $order );
 				$this->log(
 					array(
 						__METHOD__,
@@ -400,6 +401,9 @@ class OrderCapture {
 						'order' => $order->get_id(),
 						'item'  => $item->get_id(),
 						'msg'   => 'Skipping bundle product',
+						'data'  => array(
+							'$item_data' => $item_data,
+						),
 					)
 				);
 				continue;

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -340,26 +340,30 @@ class OrderCapture {
 		);
 
 		if ( is_array( $invoice_data ) && array_key_exists( 'order_lines', $invoice_data ) ) {
+			$this->log( sprintf( 'Capture order: %s checking surcharge fee', $invoice_data['handle'] ) );
 			foreach ( $invoice_data['order_lines'] as $invoice_line ) {
-				$is_exist = false;
-				foreach ( $order->get_items( 'fee' ) as $item ) {
-					if ( $item['name'] === $invoice_line['ordertext'] ) {
-						$is_exist = true;
+				if ( 'surcharge_fee' === $invoice_line['origin'] ) {
+					$is_exist = false;
+					foreach ( $order->get_items( 'fee' ) as $item ) {
+						if ( $item->get_name() === $invoice_line['ordertext'] ) {
+							$is_exist = true;
+							break;
+						}
 					}
-				}
-
-				if ( ! $is_exist ) {
-					if ( 'surcharge_fee' === $invoice_line['origin'] ) {
+					if ( ! $is_exist ) {
+						$this->log( sprintf( 'Capture order: %s adding surcharge fee', $invoice_data['handle'] ) );
 						$fees_item = new WC_Order_Item_Fee();
 						$fees_item->set_name( $invoice_line['ordertext'] );
 						$fees_item->set_amount( floatval( $invoice_line['unit_amount'] ) / 100 );
 						$fees_item->set_total( floatval( $invoice_line['amount'] ) / 100 );
-						$fees_item->set_tax_class( 'zero-rate' );
+						$fees_item->set_tax_status( 'none' );
 						$fees_item->add_meta_data( '_is_card_fee', true );
 						$order->add_item( $fees_item );
-
 						$order->calculate_totals( false );
 						$order->save();
+						$this->log( sprintf( 'Capture order: %s surcharge fee added', $invoice_data['handle'] ) );
+					} else {
+						$this->log( sprintf( 'Capture order: %s surcharge fee already exists', $invoice_data['handle'] ) );
 					}
 				}
 			}

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -391,6 +391,20 @@ class OrderCapture {
 				)
 			);
 
+			// Skip bundle products to be consistent with other methods.
+			if ( WPCProductBundlesWooCommerceIntegration::is_order_item_bundle( $item ) ) {
+				$this->log(
+					array(
+						__METHOD__,
+						__LINE__,
+						'order' => $order->get_id(),
+						'item'  => $item->get_id(),
+						'msg'   => 'Skipping bundle product',
+					)
+				);
+				continue;
+			}
+
 			if ( empty( $item->get_meta( 'settled' ) ) ) {
 				$item_data = $this->get_item_data( $item, $order );
 				$price     = self::get_item_price( $item, $order );

--- a/includes/OrderFlow/OrderStatuses.php
+++ b/includes/OrderFlow/OrderStatuses.php
@@ -261,10 +261,9 @@ class OrderStatuses {
 
 		// Trigger WooCommerce update hook for analytics.
 		do_action( 'woocommerce_update_order', $order->get_id() );
-		//do_action( 'woocommerce_analytics_update_order_stats', $order->get_id() );
 
-		// Trigger order save to ensure analytics are updated
-		$order = wc_get_order( $order->get_id());
+		// Trigger order save to ensure analytics are updated.
+		$order = wc_get_order( $order->get_id() );
 		if ( $order ) {
 			$order->save();
 		}
@@ -308,10 +307,9 @@ class OrderStatuses {
 
 		// Trigger WooCommerce update hook for analytics.
 		do_action( 'woocommerce_update_order', $order->get_id() );
-		//do_action( 'woocommerce_analytics_update_order_stats', $order->get_id() );
 
-		// Trigger order save to ensure analytics are updated
-		$order = wc_get_order( $order->get_id());
+		// Trigger order save to ensure analytics are updated.
+		$order = wc_get_order( $order->get_id() );
 		if ( $order ) {
 			$order->save();
 		}

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,7 +4,7 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Frisbii
  * Author URI: https://frisbii.com
- * Version: 1.8.2.1
+ * Version: 1.8.3
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0


### PR DESCRIPTION
v 1.8.3
- [FIX] - In case Frisbii process a renewal successfully for a subscriptionorder that is marked as Completed in WooCommerce then the order note will not say the settlement failed and the invoice wasn't found.
- [Fix] - Replaces calls to buggy sync_order API endpoint in WooCommerce 10.1.0.
- [Fix] - An order note "Payment has been settled" was missing when capturing all items for orders containing bundle products.
- [Fix] - The order is updated with any surcharge fees when charged.