### PR TITLE
Ensure compliance with everyone else using the 'woocommerce_update_order' hook

### DIFF
--- a/includes/Analytics/AnalyticsSync.php
+++ b/includes/Analytics/AnalyticsSync.php
@@ -71,12 +71,13 @@ class AnalyticsSync {
 	private function force_analytics_sync( $order_id ) {
 		// Trigger order save to ensure analytics are updated.
 		$order = wc_get_order( $order_id );
-		if ( $order ) {
-			$order->save();
-		}
 
 		// Trigger the WooCommerce update hook.
 		do_action( 'woocommerce_update_order', $order_id, $order );
+
+		if ( $order ) {
+			$order->save();
+		}
 	}
 
 	/**

--- a/includes/Analytics/AnalyticsSync.php
+++ b/includes/Analytics/AnalyticsSync.php
@@ -69,14 +69,14 @@ class AnalyticsSync {
 	 * @param int $order_id Order ID.
 	 */
 	private function force_analytics_sync( $order_id ) {
-		// Trigger the WooCommerce update hook.
-		do_action( 'woocommerce_update_order', $order_id );
-
 		// Trigger order save to ensure analytics are updated.
 		$order = wc_get_order( $order_id );
 		if ( $order ) {
 			$order->save();
 		}
+
+		// Trigger the WooCommerce update hook.
+		do_action( 'woocommerce_update_order', $order_id, $order );
 	}
 
 	/**


### PR DESCRIPTION
The 'woocommerce_update_order' action now passes both the order ID and order object. This ensures that the action is triggered the same way as WooCommerce implemented it, and ensures compliance with everyone else using this hook.

References:
https://github.com/woocommerce/woocommerce/blob/e653a4e8e8d50e4ee2a08d051277b60fb4d94dd9/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L2880
https://github.com/woocommerce/woocommerce/blob/e653a4e8e8d50e4ee2a08d051277b60fb4d94dd9/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php#L237
