### PR TITLE
v 1.8.12

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -4,7 +4,7 @@ Tags: Frisbii, billwerk+, visa, mastercard, dankort, mobilepay
 Requires at least: 4.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.8.11
+Stable tag: 1.8.12
 License: GPL
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 
@@ -18,6 +18,11 @@ The Frisbii Pay plugin extends WooCommerce allowing you to take payments on your
 See installation guide right here: https://docu.billwerk.plus/help/en/apps/woocommerce/setup-woocommerce-plugin.html
 
 == Changelog ==
+v 1.8.12
+- [Fix] - Setting "Status: Frisbii Pay Settled" applies to Subscription renewal orders.
+- [Fix] - Adds compatibility declaration for WooCommerce Blocks checkout.
+- [Improvement] - General security patches.
+
 v 1.8.11
 - [Improvement] - Applepay payment option no longer depends on device and  browser type
 

--- a/assets/js/migration-mobilepay-vippsmobilepay.js
+++ b/assets/js/migration-mobilepay-vippsmobilepay.js
@@ -39,6 +39,7 @@ jQuery(function ($) {
 
         var formData = new FormData();
         formData.append('action', 'reepay_migration_upload_csv');
+        formData.append('nonce', migrationData.nonce);
         formData.append('migration_file', $('#migration_file')[0].files[0]);
         $.ajax({
             url: ajaxurl,
@@ -62,6 +63,7 @@ jQuery(function ($) {
             type: 'POST',
             data: {
                 action: 'reepay_migration_process_batch',
+                nonce: migrationData.nonce,
                 offset: offset
             },
             success: function(response) {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.",
     "type": "wordpress-plugin",
     "license": "GPL",
-    "version": "1.8.11",
+    "version": "1.8.12",
     "autoload": {
         "psr-4": {
             "Reepay\\Checkout\\": "includes/",

--- a/includes/Actions/Admin.php
+++ b/includes/Actions/Admin.php
@@ -133,14 +133,24 @@ class Admin {
 		$rows[] = esc_html( 'WooCommerce activated: ' . ( $woo_class_exists && $wc_abspath_defined ? 'yes' : 'no' ) );
 		$rows[] = esc_html( 'WooCommerce version: ' . $woo_version );
 
-		// --- WoocommerceHPOS ---
+		// --- WoocommerceHPOS + FeaturesUtil ---
+		$plugin_file          = (string) reepay()->get_setting( 'plugin_file' );
 		$hpos_enabled         = 'yes' === get_option( 'woocommerce_custom_orders_table_enabled', 'no' );
 		$features_util_exists = class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' );
+		$order_util_exists    = class_exists( '\Automattic\WooCommerce\Utilities\OrderUtil' );
 
 		$rows[] = '';
-		$rows[] = '<strong>' . esc_html__( 'HPOS (WoocommerceHPOS)', 'reepay-checkout-gateway' ) . '</strong>';
-		$rows[] = esc_html( 'hpos enabled: ' . ( $hpos_enabled ? 'yes' : 'no' ) );
+		$rows[] = '<strong>' . esc_html__( 'HPOS / FeaturesUtil (WoocommerceHPOS + OrderTable + hpos.php)', 'reepay-checkout-gateway' ) . '</strong>';
+		$rows[] = esc_html( 'plugin_file (used in declare_compatibility): ' . $plugin_file );
+		$rows[] = esc_html( 'plugin_basename (used in get_compatible_features): ' . $plugin_basename );
+		$rows[] = esc_html( 'hpos enabled (DB option): ' . ( $hpos_enabled ? 'yes' : 'no' ) );
 		$rows[] = esc_html( 'FeaturesUtil available: ' . ( $features_util_exists ? 'yes' : 'no' ) );
+		$rows[] = esc_html( 'OrderUtil available: ' . ( $order_util_exists ? 'yes' : 'no' ) );
+
+		if ( $order_util_exists ) {
+			$hpos_actually_enabled = \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+			$rows[]                = esc_html( 'OrderUtil::custom_orders_table_usage_is_enabled(): ' . ( $hpos_actually_enabled ? 'yes' : 'no' ) );
+		}
 
 		if ( $features_util_exists ) {
 			$compatibility = \Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_features_for_plugin( $plugin_basename );
@@ -150,6 +160,26 @@ class Admin {
 			$rows[]        = esc_html( 'custom_order_tables compatible: ' . ( in_array( 'custom_order_tables', $compatible, true ) ? 'yes' : 'no' ) );
 			$rows[]        = esc_html( 'custom_order_tables incompatible: ' . ( in_array( 'custom_order_tables', $incompatible, true ) ? 'yes' : 'no' ) );
 			$rows[]        = esc_html( 'custom_order_tables uncertain: ' . ( in_array( 'custom_order_tables', $uncertain, true ) ? 'yes' : 'no' ) );
+		}
+
+		// --- WooCommerce Blocks / cart_checkout_blocks (WooBlocksIntegration) ---
+		// NOTE: The plugin registers payment methods with WooCommerce Blocks but does NOT
+		// call FeaturesUtil::declare_compatibility('cart_checkout_blocks', ...) anywhere.
+		// WooCommerce will therefore flag this plugin as NOT declared for cart_checkout_blocks.
+		$blocks_package_exists   = class_exists( '\Automattic\WooCommerce\Blocks\Package' );
+		$blocks_registry_exists  = class_exists( '\Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry' );
+
+		$rows[] = '';
+		$rows[] = '<strong>' . esc_html__( 'WooCommerce Blocks (WooBlocksIntegration)', 'reepay-checkout-gateway' ) . '</strong>';
+		$rows[] = esc_html( 'Blocks\Package available: ' . ( $blocks_package_exists ? 'yes' : 'no' ) );
+		$rows[] = esc_html( 'Blocks\PaymentMethodRegistry available: ' . ( $blocks_registry_exists ? 'yes' : 'no' ) );
+
+		if ( $features_util_exists ) {
+			// Reuse $compatibility already fetched above.
+			$rows[] = esc_html( 'cart_checkout_blocks compatible: ' . ( in_array( 'cart_checkout_blocks', $compatible, true ) ? 'yes' : 'no' ) );
+			$rows[] = esc_html( 'cart_checkout_blocks incompatible: ' . ( in_array( 'cart_checkout_blocks', $incompatible, true ) ? 'yes' : 'no' ) );
+			$rows[] = esc_html( 'cart_checkout_blocks uncertain: ' . ( in_array( 'cart_checkout_blocks', $uncertain, true ) ? 'yes' : 'no' ) );
+			$rows[] = '<strong style="color:#d63638">' . esc_html__( 'WARNING: cart_checkout_blocks is never declared — plugin uses WooCommerce Blocks but is missing declare_compatibility()', 'reepay-checkout-gateway' ) . '</strong>';
 		}
 
 		// --- UpdateDB / LifeCycle ---

--- a/includes/Actions/Admin.php
+++ b/includes/Actions/Admin.php
@@ -19,6 +19,7 @@ class Admin {
 	public function __construct() {
 		add_action( 'admin_notices', array( $this, 'admin_notice_api_action' ) );
 		add_action( 'admin_notices', array( $this, 'billwerk_pay_hpos_check' ) );
+		add_action( 'admin_notices', array( $this, 'debug_plugin_status' ) );
 	}
 
 	/**
@@ -80,5 +81,97 @@ class Admin {
 				__( 'Frisbii works best with High Performance Order Storage. You can activate it in the WooCommerce settings under the "Advanced" tab, "Features" sub-tab.', 'reepay-checkout-gateway' ) .
 				'</p></div>';
 		}
+	}
+
+	/**
+	 * Display a temporary full plugin status debug notice on the plugins page.
+	 * Covers all classes in the Plugin namespace: WoocommerceExists, WoocommerceHPOS,
+	 * LifeCycle, UpdateDB, and Statistics.
+	 * Enable with /wp-admin/plugins.php?reepay_hpos_debug=1
+	 */
+	public function debug_plugin_status() {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+		if ( ! function_exists( 'get_current_screen' ) || ! function_exists( 'reepay' ) ) {
+			return;
+		}
+		$screen = get_current_screen();
+		if ( ! $screen || 'plugins' !== $screen->id ) {
+			return;
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['reepay_hpos_debug'] ) || '1' !== sanitize_text_field( wp_unslash( $_GET['reepay_hpos_debug'] ) ) ) {
+			return;
+		}
+
+		$rows = array();
+
+		// --- Plugin Info ---
+		$plugin_version   = (string) reepay()->get_setting( 'plugin_version' );
+		$plugin_basename  = (string) reepay()->get_setting( 'plugin_basename' );
+		$test_mode        = reepay()->get_setting( 'test_mode' );
+		$private_key      = reepay()->get_setting( 'private_key' );
+		$private_key_test = reepay()->get_setting( 'private_key_test' );
+
+		$rows[] = '<strong>' . esc_html__( 'Plugin Info', 'reepay-checkout-gateway' ) . '</strong>';
+		$rows[] = esc_html( 'version: ' . $plugin_version );
+		$rows[] = esc_html( 'basename: ' . $plugin_basename );
+		$rows[] = esc_html( 'test mode: ' . ( 'yes' === $test_mode ? 'yes' : 'no' ) );
+		$rows[] = esc_html( 'private key (live) configured: ' . ( ! empty( $private_key ) ? 'yes' : 'no' ) );
+		$rows[] = esc_html( 'private key (test) configured: ' . ( ! empty( $private_key_test ) ? 'yes' : 'no' ) );
+
+		// --- WoocommerceExists ---
+		$woo_class_exists   = class_exists( 'WooCommerce', false );
+		$wc_abspath_defined = defined( 'WC_ABSPATH' );
+		$woo_version        = ( $woo_class_exists && function_exists( 'WC' ) && WC() ) ? (string) WC()->version : 'n/a';
+
+		$rows[] = '';
+		$rows[] = '<strong>' . esc_html__( 'WooCommerce (WoocommerceExists)', 'reepay-checkout-gateway' ) . '</strong>';
+		$rows[] = esc_html( 'WooCommerce class exists: ' . ( $woo_class_exists ? 'yes' : 'no' ) );
+		$rows[] = esc_html( 'WC_ABSPATH defined: ' . ( $wc_abspath_defined ? 'yes' : 'no' ) );
+		$rows[] = esc_html( 'WooCommerce activated: ' . ( $woo_class_exists && $wc_abspath_defined ? 'yes' : 'no' ) );
+		$rows[] = esc_html( 'WooCommerce version: ' . $woo_version );
+
+		// --- WoocommerceHPOS ---
+		$hpos_enabled         = 'yes' === get_option( 'woocommerce_custom_orders_table_enabled', 'no' );
+		$features_util_exists = class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' );
+
+		$rows[] = '';
+		$rows[] = '<strong>' . esc_html__( 'HPOS (WoocommerceHPOS)', 'reepay-checkout-gateway' ) . '</strong>';
+		$rows[] = esc_html( 'hpos enabled: ' . ( $hpos_enabled ? 'yes' : 'no' ) );
+		$rows[] = esc_html( 'FeaturesUtil available: ' . ( $features_util_exists ? 'yes' : 'no' ) );
+
+		if ( $features_util_exists ) {
+			$compatibility = \Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_features_for_plugin( $plugin_basename );
+			$compatible    = $compatibility['compatible'] ?? array();
+			$incompatible  = $compatibility['incompatible'] ?? array();
+			$uncertain     = $compatibility['uncertain'] ?? array();
+			$rows[]        = esc_html( 'custom_order_tables compatible: ' . ( in_array( 'custom_order_tables', $compatible, true ) ? 'yes' : 'no' ) );
+			$rows[]        = esc_html( 'custom_order_tables incompatible: ' . ( in_array( 'custom_order_tables', $incompatible, true ) ? 'yes' : 'no' ) );
+			$rows[]        = esc_html( 'custom_order_tables uncertain: ' . ( in_array( 'custom_order_tables', $uncertain, true ) ? 'yes' : 'no' ) );
+		}
+
+		// --- UpdateDB / LifeCycle ---
+		$stored_db_version = (string) get_option( 'woocommerce_reepay_version', 'not set' );
+		$latest_db_version = \Reepay\Checkout\Plugin\UpdateDB::DB_VERSION;
+		$db_update_needed  = ( 'not set' !== $stored_db_version && version_compare( $stored_db_version, $latest_db_version, '<' ) ) ? 'yes' : 'no';
+
+		$rows[] = '';
+		$rows[] = '<strong>' . esc_html__( 'Database / LifeCycle (UpdateDB)', 'reepay-checkout-gateway' ) . '</strong>';
+		$rows[] = esc_html( 'stored db version: ' . $stored_db_version );
+		$rows[] = esc_html( 'latest db version: ' . $latest_db_version );
+		$rows[] = esc_html( 'db update needed: ' . $db_update_needed );
+
+		// --- Statistics ---
+		$stats_active = \Reepay\Checkout\Plugin\Statistics::get_instance() instanceof \Reepay\Checkout\Plugin\Statistics;
+
+		$rows[] = '';
+		$rows[] = '<strong>' . esc_html__( 'Statistics', 'reepay-checkout-gateway' ) . '</strong>';
+		$rows[] = esc_html( 'Statistics instance active: ' . ( $stats_active ? 'yes' : 'no' ) );
+
+		echo '<div class="notice notice-info"><p>' .
+			implode( '<br>', $rows ) .
+			'</p></div>';
 	}
 }

--- a/includes/Actions/Admin.php
+++ b/includes/Actions/Admin.php
@@ -114,7 +114,7 @@ class Admin {
 		$private_key      = reepay()->get_setting( 'private_key' );
 		$private_key_test = reepay()->get_setting( 'private_key_test' );
 
-		$rows[] = '<strong>' . esc_html__( 'Plugin Info', 'reepay-checkout-gateway' ) . '</strong>';
+		$rows[] = '<strong>' . esc_html__( 'Fribii Pay Plugin Debug Info', 'reepay-checkout-gateway' ) . '</strong>';
 		$rows[] = esc_html( 'version: ' . $plugin_version );
 		$rows[] = esc_html( 'basename: ' . $plugin_basename );
 		$rows[] = esc_html( 'test mode: ' . ( 'yes' === $test_mode ? 'yes' : 'no' ) );
@@ -163,11 +163,8 @@ class Admin {
 		}
 
 		// --- WooCommerce Blocks / cart_checkout_blocks (WooBlocksIntegration) ---
-		// NOTE: The plugin registers payment methods with WooCommerce Blocks but does NOT
-		// call FeaturesUtil::declare_compatibility('cart_checkout_blocks', ...) anywhere.
-		// WooCommerce will therefore flag this plugin as NOT declared for cart_checkout_blocks.
-		$blocks_package_exists   = class_exists( '\Automattic\WooCommerce\Blocks\Package' );
-		$blocks_registry_exists  = class_exists( '\Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry' );
+		$blocks_package_exists  = class_exists( '\Automattic\WooCommerce\Blocks\Package' );
+		$blocks_registry_exists = class_exists( '\Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry' );
 
 		$rows[] = '';
 		$rows[] = '<strong>' . esc_html__( 'WooCommerce Blocks (WooBlocksIntegration)', 'reepay-checkout-gateway' ) . '</strong>';
@@ -179,7 +176,6 @@ class Admin {
 			$rows[] = esc_html( 'cart_checkout_blocks compatible: ' . ( in_array( 'cart_checkout_blocks', $compatible, true ) ? 'yes' : 'no' ) );
 			$rows[] = esc_html( 'cart_checkout_blocks incompatible: ' . ( in_array( 'cart_checkout_blocks', $incompatible, true ) ? 'yes' : 'no' ) );
 			$rows[] = esc_html( 'cart_checkout_blocks uncertain: ' . ( in_array( 'cart_checkout_blocks', $uncertain, true ) ? 'yes' : 'no' ) );
-			$rows[] = '<strong style="color:#d63638">' . esc_html__( 'WARNING: cart_checkout_blocks is never declared — plugin uses WooCommerce Blocks but is missing declare_compatibility()', 'reepay-checkout-gateway' ) . '</strong>';
 		}
 
 		// --- UpdateDB / LifeCycle ---

--- a/includes/Admin/Ajax.php
+++ b/includes/Admin/Ajax.php
@@ -80,6 +80,16 @@ class Ajax {
 		$order_id = (int) wc_clean( $_REQUEST['order_id'] );
 		$order    = wc_get_order( $order_id );
 
+		// Security: Validate order exists and belongs to Reepay
+		if ( ! $order || ! $order instanceof WC_Order ) {
+			wp_send_json_error( __( 'Invalid order', 'reepay-checkout-gateway' ) );
+		}
+
+		// Security: Verify order is paid via Reepay
+		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
+			wp_send_json_error( __( 'Order not paid via Reepay', 'reepay-checkout-gateway' ) );
+		}
+
 		try {
 			$gateway = rp_get_payment_method( $order );
 			$gateway->capture_payment( $order, $order->get_total() );
@@ -102,6 +112,16 @@ class Ajax {
 
 		$order_id = (int) wc_clean( $_REQUEST['order_id'] );
 		$order    = wc_get_order( $order_id );
+
+		// Security: Validate order exists and belongs to Reepay
+		if ( ! $order || ! $order instanceof WC_Order ) {
+			wp_send_json_error( __( 'Invalid order', 'reepay-checkout-gateway' ) );
+		}
+
+		// Security: Verify order is paid via Reepay
+		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
+			wp_send_json_error( __( 'Order not paid via Reepay', 'reepay-checkout-gateway' ) );
+		}
 
 		// Check if the order is already cancelled.
 		if ( '1' === $order->get_meta( '_reepay_order_cancelled' ) ) {
@@ -138,6 +158,16 @@ class Ajax {
 
 		$order_id = (int) wc_clean( $_REQUEST['order_id'] );
 		$order    = wc_get_order( $order_id );
+
+		// Security: Validate order exists and belongs to Reepay
+		if ( ! $order || ! $order instanceof WC_Order ) {
+			wp_send_json_error( __( 'Invalid order', 'reepay-checkout-gateway' ) );
+		}
+
+		// Security: Verify order is paid via Reepay
+		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
+			wp_send_json_error( __( 'Order not paid via Reepay', 'reepay-checkout-gateway' ) );
+		}
 
 		$amount = ! empty( $_REQUEST['amount'] ) ? (int) wc_clean( $_REQUEST['amount'] ) : false;
 

--- a/includes/Admin/Ajax.php
+++ b/includes/Admin/Ajax.php
@@ -80,12 +80,12 @@ class Ajax {
 		$order_id = (int) wc_clean( $_REQUEST['order_id'] );
 		$order    = wc_get_order( $order_id );
 
-		// Security: Validate order exists and belongs to Reepay
+		// Security: Validate order exists and belongs to Reepay.
 		if ( ! $order || ! $order instanceof WC_Order ) {
 			wp_send_json_error( __( 'Invalid order', 'reepay-checkout-gateway' ) );
 		}
 
-		// Security: Verify order is paid via Reepay
+		// Security: Verify order is paid via Reepay.
 		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
 			wp_send_json_error( __( 'Order not paid via Reepay', 'reepay-checkout-gateway' ) );
 		}
@@ -113,12 +113,12 @@ class Ajax {
 		$order_id = (int) wc_clean( $_REQUEST['order_id'] );
 		$order    = wc_get_order( $order_id );
 
-		// Security: Validate order exists and belongs to Reepay
+		// Security: Validate order exists and belongs to Reepay.
 		if ( ! $order || ! $order instanceof WC_Order ) {
 			wp_send_json_error( __( 'Invalid order', 'reepay-checkout-gateway' ) );
 		}
 
-		// Security: Verify order is paid via Reepay
+		// Security: Verify order is paid via Reepay.
 		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
 			wp_send_json_error( __( 'Order not paid via Reepay', 'reepay-checkout-gateway' ) );
 		}
@@ -159,12 +159,12 @@ class Ajax {
 		$order_id = (int) wc_clean( $_REQUEST['order_id'] );
 		$order    = wc_get_order( $order_id );
 
-		// Security: Validate order exists and belongs to Reepay
+		// Security: Validate order exists and belongs to Reepay.
 		if ( ! $order || ! $order instanceof WC_Order ) {
 			wp_send_json_error( __( 'Invalid order', 'reepay-checkout-gateway' ) );
 		}
 
-		// Security: Verify order is paid via Reepay
+		// Security: Verify order is paid via Reepay.
 		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
 			wp_send_json_error( __( 'Order not paid via Reepay', 'reepay-checkout-gateway' ) );
 		}

--- a/includes/Admin/Ajax.php
+++ b/includes/Admin/Ajax.php
@@ -61,7 +61,7 @@ class Ajax {
 		}
 
 		if ( ! wp_verify_nonce( $_REQUEST['nonce'] ?? '', $action ) ) {
-			exit( 'No naughty business' );
+			wp_send_json_error( 'Invalid nonce', 403 );
 		}
 
 		return true;

--- a/includes/Admin/MigrationMobilepayToVipps.php
+++ b/includes/Admin/MigrationMobilepayToVipps.php
@@ -135,18 +135,23 @@ class MigrationMobilepayToVipps {
 		check_ajax_referer( 'reepay_migration_nonce', 'nonce' );
 
 		if ( ! empty( $_FILES['migration_file']['tmp_name'] ) ) {
-			// Security: Validate file type
+			// Ensure required file fields are present.
+			if ( ! isset( $_FILES['migration_file']['name'], $_FILES['migration_file']['size'] ) ) {
+				wp_send_json_error( 'Invalid file data.' );
+			}
+
+			// Security: Validate file type.
 			$file_type = wp_check_filetype_and_ext(
 				$_FILES['migration_file']['tmp_name'],
 				$_FILES['migration_file']['name'],
 				array( 'csv' => 'text/csv' )
 			);
 
-			if ( ! $file_type['ext'] || $file_type['ext'] !== 'csv' ) {
+			if ( ! $file_type['ext'] || 'csv' !== $file_type['ext'] ) {
 				wp_send_json_error( 'Invalid file type. Only CSV files are allowed.' );
 			}
 
-			// Security: Validate file size (max 5MB)
+			// Security: Validate file size (max 5MB).
 			if ( $_FILES['migration_file']['size'] > 5 * 1024 * 1024 ) {
 				wp_send_json_error( 'File too large. Maximum size is 5MB.' );
 			}
@@ -162,14 +167,14 @@ class MigrationMobilepayToVipps {
 			if ( $wp_filesystem->exists( $csv_file ) ) {
 				$file_content = $wp_filesystem->get_contents( $csv_file );
 
-				// Security: Validate file is not too large
+				// Security: Validate file is not too large.
 				if ( strlen( $file_content ) > 5 * 1024 * 1024 ) {
 					wp_send_json_error( 'File content too large.' );
 				}
 
 				$lines = explode( "\n", $file_content );
 
-				// Security: Validate CSV structure
+				// Security: Validate CSV structure.
 				if ( count( $lines ) > 10000 ) {
 					wp_send_json_error( 'File contains too many lines. Maximum 10,000 records.' );
 				}
@@ -183,7 +188,7 @@ class MigrationMobilepayToVipps {
 				$csv_data = array_map(
 					function ( $row ) use ( $delimiter ) {
 						$parsed_row = str_getcsv( $row, $delimiter );
-						// Security: Sanitize CSV values to prevent formula injection
+						// Security: Sanitize CSV values to prevent formula injection.
 						return array_map( array( $this, 'sanitize_csv_value' ), $parsed_row );
 					},
 					$lines
@@ -450,12 +455,12 @@ class MigrationMobilepayToVipps {
 			return $value;
 		}
 
-		// Security: List of formula indicators that could be exploited
+		// Security: List of formula indicators that could be exploited.
 		$formula_indicators = array( '=', '+', '-', '@', "\t", "\r" );
 
-		// Check if value starts with a formula indicator
+		// Check if value starts with a formula indicator.
 		if ( in_array( substr( $value, 0, 1 ), $formula_indicators, true ) ) {
-			// Prefix with single quote to force text interpretation in spreadsheet applications
+			// Prefix with single quote to force text interpretation in spreadsheet applications.
 			$value = "'" . $value;
 		}
 

--- a/includes/Admin/MigrationMobilepayToVipps.php
+++ b/includes/Admin/MigrationMobilepayToVipps.php
@@ -135,6 +135,21 @@ class MigrationMobilepayToVipps {
 		check_ajax_referer( 'reepay_migration_nonce', 'nonce' );
 
 		if ( ! empty( $_FILES['migration_file']['tmp_name'] ) ) {
+			// Security: Validate file type
+			$file_type = wp_check_filetype_and_ext(
+				$_FILES['migration_file']['tmp_name'],
+				$_FILES['migration_file']['name'],
+				array( 'csv' => 'text/csv' )
+			);
+
+			if ( ! $file_type['ext'] || $file_type['ext'] !== 'csv' ) {
+				wp_send_json_error( 'Invalid file type. Only CSV files are allowed.' );
+			}
+
+			// Security: Validate file size (max 5MB)
+			if ( $_FILES['migration_file']['size'] > 5 * 1024 * 1024 ) {
+				wp_send_json_error( 'File too large. Maximum size is 5MB.' );
+			}
 
 			global $wp_filesystem;
 			if ( empty( $wp_filesystem ) ) {
@@ -146,7 +161,18 @@ class MigrationMobilepayToVipps {
 
 			if ( $wp_filesystem->exists( $csv_file ) ) {
 				$file_content = $wp_filesystem->get_contents( $csv_file );
+
+				// Security: Validate file is not too large
+				if ( strlen( $file_content ) > 5 * 1024 * 1024 ) {
+					wp_send_json_error( 'File content too large.' );
+				}
+
 				$lines        = explode( "\n", $file_content );
+
+				// Security: Validate CSV structure
+				if ( count( $lines ) > 10000 ) {
+					wp_send_json_error( 'File contains too many lines. Maximum 10,000 records.' );
+				}
 				$first_line   = $lines[0]; // Get the first line.
 				if ( strpos( $first_line, ';' ) !== false ) {
 					$delimiter = ';'; // set delimiter to semicolon.
@@ -183,7 +209,7 @@ class MigrationMobilepayToVipps {
 
 		global $wpdb;
 
-		$offset   = isset( $_POST['offset'] ) ? intval( $_POST['offset'] ) : 0;
+		$offset   = isset( $_POST['offset'] ) ? absint( $_POST['offset'] ) : 0;
 		$csv_data = get_option( 'reepay_csv_data_migration_mobilepay_to_vipps', array() );
 
 		if ( empty( $csv_data ) ) {

--- a/includes/Admin/MigrationMobilepayToVipps.php
+++ b/includes/Admin/MigrationMobilepayToVipps.php
@@ -182,7 +182,9 @@ class MigrationMobilepayToVipps {
 
 				$csv_data = array_map(
 					function ( $row ) use ( $delimiter ) {
-						return str_getcsv( $row, $delimiter );
+						$parsed_row = str_getcsv( $row, $delimiter );
+						// Security: Sanitize CSV values to prevent formula injection
+						return array_map( array( $this, 'sanitize_csv_value' ), $parsed_row );
 					},
 					$lines
 				);
@@ -432,6 +434,32 @@ class MigrationMobilepayToVipps {
 				'batch_results' => $batch_results,
 			)
 		);
+	}
+
+	/**
+	 * Sanitize CSV value to prevent formula injection
+	 *
+	 * Security: Prevents CSV/Formula injection attacks by escaping values
+	 * that start with formula indicators (=, +, -, @, tab, carriage return)
+	 *
+	 * @param string $value The CSV value to sanitize.
+	 * @return string Sanitized value.
+	 */
+	private function sanitize_csv_value( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
+		// Security: List of formula indicators that could be exploited
+		$formula_indicators = array( '=', '+', '-', '@', "\t", "\r" );
+
+		// Check if value starts with a formula indicator
+		if ( in_array( substr( $value, 0, 1 ), $formula_indicators, true ) ) {
+			// Prefix with single quote to force text interpretation in spreadsheet applications
+			$value = "'" . $value;
+		}
+
+		return sanitize_text_field( $value );
 	}
 }
 ?>

--- a/includes/Admin/MigrationMobilepayToVipps.php
+++ b/includes/Admin/MigrationMobilepayToVipps.php
@@ -167,13 +167,13 @@ class MigrationMobilepayToVipps {
 					wp_send_json_error( 'File content too large.' );
 				}
 
-				$lines        = explode( "\n", $file_content );
+				$lines = explode( "\n", $file_content );
 
 				// Security: Validate CSV structure
 				if ( count( $lines ) > 10000 ) {
 					wp_send_json_error( 'File contains too many lines. Maximum 10,000 records.' );
 				}
-				$first_line   = $lines[0]; // Get the first line.
+				$first_line = $lines[0]; // Get the first line.
 				if ( strpos( $first_line, ';' ) !== false ) {
 					$delimiter = ';'; // set delimiter to semicolon.
 				} else {

--- a/includes/Admin/MigrationMobilepayToVipps.php
+++ b/includes/Admin/MigrationMobilepayToVipps.php
@@ -442,10 +442,7 @@ class MigrationMobilepayToVipps {
 	}
 
 	/**
-	 * Sanitize CSV value to prevent formula injection
-	 *
-	 * Security: Prevents CSV/Formula injection attacks by escaping values
-	 * that start with formula indicators (=, +, -, @, tab, carriage return)
+	 * Sanitize CSV value for safe processing during import.
 	 *
 	 * @param string $value The CSV value to sanitize.
 	 * @return string Sanitized value.
@@ -453,15 +450,6 @@ class MigrationMobilepayToVipps {
 	private function sanitize_csv_value( $value ) {
 		if ( ! is_string( $value ) ) {
 			return $value;
-		}
-
-		// Security: List of formula indicators that could be exploited.
-		$formula_indicators = array( '=', '+', '-', '@', "\t", "\r" );
-
-		// Check if value starts with a formula indicator.
-		if ( in_array( substr( $value, 0, 1 ), $formula_indicators, true ) ) {
-			// Prefix with single quote to force text interpretation in spreadsheet applications.
-			$value = "'" . $value;
 		}
 
 		return sanitize_text_field( $value );

--- a/includes/Api/Controller/DebugController.php
+++ b/includes/Api/Controller/DebugController.php
@@ -48,7 +48,7 @@ class DebugController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Run debug code
+	 * Run debug diagnostics (safe — no arbitrary code execution).
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
@@ -59,14 +59,17 @@ class DebugController extends WP_REST_Controller {
 			return new WP_Error( 'rest_forbidden', esc_html__( 'Debug endpoint is only available when WP_DEBUG is enabled.', 'reepay-checkout-gateway' ), array( 'status' => 403 ) );
 		}
 
-		$code = $request['code'];
-		ob_start();
-
-		// @codingStandardsIgnoreStart
-		eval( '?>' . $code );
-		// @codingStandardsIgnoreEnd
-
-		return rest_ensure_response( array( 'message' => ob_get_clean() ) );
+		return rest_ensure_response(
+			array(
+				'php_version'    => PHP_VERSION,
+				'wp_version'     => get_bloginfo( 'version' ),
+				'wc_version'     => defined( 'WC_VERSION' ) ? WC_VERSION : 'N/A',
+				'plugin_version' => defined( 'REEPAY_PLUGIN_VERSION' ) ? REEPAY_PLUGIN_VERSION : 'N/A',
+				'wp_debug'       => defined( 'WP_DEBUG' ) && WP_DEBUG,
+				'php_memory'     => ini_get( 'memory_limit' ),
+				'timestamp'      => current_time( 'mysql' ),
+			)
+		);
 	}
 
 	/**

--- a/includes/Frontend/PaymentMethodsActions.php
+++ b/includes/Frontend/PaymentMethodsActions.php
@@ -66,8 +66,8 @@ class PaymentMethodsActions {
 		wc_nocache_headers();
 
 		// Security: Verify nonce first (from GET parameter)
-		if ( ! isset( $_GET['_wpnonce'] ) || 
-		     ! wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'delete-payment-method-' . $token_id ) ) {
+		if ( ! isset( $_GET['_wpnonce'] ) ||
+			! wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'delete-payment-method-' . $token_id ) ) {
 			wc_add_notice( __( 'Security check failed.', 'reepay-checkout-gateway' ), 'error' );
 			wp_safe_redirect( wc_get_account_endpoint_url( 'payment-methods' ) );
 			exit();

--- a/includes/Frontend/PaymentMethodsActions.php
+++ b/includes/Frontend/PaymentMethodsActions.php
@@ -65,29 +65,34 @@ class PaymentMethodsActions {
 
 		wc_nocache_headers();
 
-		// Check nonce and user validation.
+		// Security: Verify nonce first (from GET parameter)
+		if ( ! isset( $_GET['_wpnonce'] ) || 
+		     ! wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'delete-payment-method-' . $token_id ) ) {
+			wc_add_notice( __( 'Security check failed.', 'reepay-checkout-gateway' ), 'error' );
+			wp_safe_redirect( wc_get_account_endpoint_url( 'payment-methods' ) );
+			exit();
+		}
+
+		// Security: Verify user ownership
 		$current_user_id = get_current_user_id();
-		$token_user_id   = $token->get_user_id();
-		$nonce_isset     = isset( $_REQUEST['_wpnonce'] );
-		$nonce_value     = $nonce_isset ? $_REQUEST['_wpnonce'] : '';
-		$nonce_valid     = $nonce_isset ? wp_verify_nonce( wp_unslash( $_REQUEST['_wpnonce'] ), 'delete-payment-method-' . $token_id ) : false;
-
-		if ( $current_user_id !== $token_user_id || ! $nonce_isset || false === $nonce_valid ) {
+		if ( $current_user_id !== $token->get_user_id() ) {
 			wc_add_notice( __( 'Invalid payment method.', 'reepay-checkout-gateway' ), 'error' );
+			wp_safe_redirect( wc_get_account_endpoint_url( 'payment-methods' ) );
+			exit();
+		}
+
+		// Delete the token
+		$deleted = false;
+		if ( class_exists( ReepayTokens::class ) ) {
+			$deleted = ReepayTokens::delete_card( $token );
+		} elseif ( method_exists( ReepayGateway::class, 'is_reepay_token' ) ) {
+			$deleted = ReepayGateway::delete_card( $token );
+		}
+
+		if ( $deleted ) {
+			wc_add_notice( __( 'Payment method deleted.', 'reepay-checkout-gateway' ) );
 		} else {
-			$deleted = false;
-
-			if ( class_exists( ReepayTokens::class ) ) {
-				$deleted = ReepayTokens::delete_card( $token );
-			} elseif ( method_exists( ReepayGateway::class, 'is_reepay_token' ) ) {
-				$deleted = ReepayGateway::delete_card( $token );
-			}
-
-			if ( $deleted ) {
-				wc_add_notice( __( 'Payment method deleted.', 'reepay-checkout-gateway' ) );
-			} else {
-				wc_add_notice( __( 'Payment method cannot be deleted.', 'reepay-checkout-gateway' ) );
-			}
+			wc_add_notice( __( 'Payment method cannot be deleted.', 'reepay-checkout-gateway' ), 'error' );
 		}
 
 		wp_safe_redirect( wc_get_account_endpoint_url( 'payment-methods' ) );

--- a/includes/Frontend/PaymentMethodsActions.php
+++ b/includes/Frontend/PaymentMethodsActions.php
@@ -65,7 +65,7 @@ class PaymentMethodsActions {
 
 		wc_nocache_headers();
 
-		// Security: Verify nonce first (from GET parameter)
+		// Security: Verify nonce first (from GET parameter).
 		if ( ! isset( $_GET['_wpnonce'] ) ||
 			! wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'delete-payment-method-' . $token_id ) ) {
 			wc_add_notice( __( 'Security check failed.', 'reepay-checkout-gateway' ), 'error' );
@@ -73,7 +73,7 @@ class PaymentMethodsActions {
 			exit();
 		}
 
-		// Security: Verify user ownership
+		// Security: Verify user ownership.
 		$current_user_id = get_current_user_id();
 		if ( $current_user_id !== $token->get_user_id() ) {
 			wc_add_notice( __( 'Invalid payment method.', 'reepay-checkout-gateway' ), 'error' );
@@ -81,7 +81,7 @@ class PaymentMethodsActions {
 			exit();
 		}
 
-		// Delete the token
+		// Delete the token.
 		$deleted = false;
 		if ( class_exists( ReepayTokens::class ) ) {
 			$deleted = ReepayTokens::delete_card( $token );

--- a/includes/Functions/hpos.php
+++ b/includes/Functions/hpos.php
@@ -27,5 +27,17 @@ function rp_hpos_enabled(): bool {
  * @return bool
  */
 function rp_hpos_is_order_page(): bool {
-	return is_admin() && rp_hpos_enabled() && isset( $_GET['id'] ) && wc_get_order( $_GET['id'] );
+	// Security: Validate GET parameter before use
+	if ( ! is_admin() || ! rp_hpos_enabled() || ! isset( $_GET['id'] ) ) {
+		return false;
+	}
+
+	// Security: Sanitize and validate order ID
+	$order_id = absint( $_GET['id'] );
+
+	if ( $order_id <= 0 ) {
+		return false;
+	}
+
+	return (bool) wc_get_order( $order_id );
 }

--- a/includes/Functions/hpos.php
+++ b/includes/Functions/hpos.php
@@ -27,12 +27,12 @@ function rp_hpos_enabled(): bool {
  * @return bool
  */
 function rp_hpos_is_order_page(): bool {
-	// Security: Validate GET parameter before use
+	// Security: Validate GET parameter before use.
 	if ( ! is_admin() || ! rp_hpos_enabled() || ! isset( $_GET['id'] ) ) {
 		return false;
 	}
 
-	// Security: Sanitize and validate order ID
+	// Security: Sanitize and validate order ID.
 	$order_id = absint( $_GET['id'] );
 
 	if ( $order_id <= 0 ) {

--- a/includes/Gateways/ReepayCheckout.php
+++ b/includes/Gateways/ReepayCheckout.php
@@ -784,7 +784,7 @@ class ReepayCheckout extends ReepayGateway {
 	 * @see ReepayGateway::change_payment_method
 	 */
 	public function reepay_finalize() {
-		// Security: Verify nonce
+		// Security: Verify nonce.
 		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'reepay_finalize' ) ) {
 			wc_add_notice( __( 'Security check failed. Please try again.', 'reepay-checkout-gateway' ), 'error' );
 			wp_redirect( wc_get_checkout_url() );

--- a/includes/Gateways/ReepayCheckout.php
+++ b/includes/Gateways/ReepayCheckout.php
@@ -784,6 +784,13 @@ class ReepayCheckout extends ReepayGateway {
 	 * @see ReepayGateway::change_payment_method
 	 */
 	public function reepay_finalize() {
+		// Security: Verify nonce
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'reepay_finalize' ) ) {
+			wc_add_notice( __( 'Security check failed. Please try again.', 'reepay-checkout-gateway' ), 'error' );
+			wp_redirect( wc_get_checkout_url() );
+			exit();
+		}
+
 		try {
 			$this->log(
 				array(

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -225,6 +225,7 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 		}
 
 		$accept_url = add_query_arg( 'action', 'reepay_card_store_' . $this->id, admin_url( 'admin-ajax.php' ) );
+		$accept_url = add_query_arg( '_wpnonce', wp_create_nonce( 'reepay_add_card' ), $accept_url );
 		$accept_url = apply_filters( 'woocommerce_reepay_payment_accept_url', $accept_url );
 		$cancel_url = wc_get_account_endpoint_url( 'payment-methods' );
 		$cancel_url = apply_filters( 'woocommerce_reepay_payment_cancel_url', $cancel_url );

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -814,7 +814,10 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 			);
 
 			try {
-				$_POST = json_decode( file_get_contents( 'php://input' ), true );
+				$json_data = json_decode( file_get_contents( 'php://input' ), true );
+				if ( is_array( $json_data ) ) {
+					$_POST = $json_data;
+				}
 				foreach ( $_POST['payment_data'] ?? array() as $data ) {
 					if ( empty( $_POST[ $data['key'] ] ) ) {
 						$_POST[ $data['key'] ] = $data['value'];

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -1493,8 +1493,9 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 				),
 				'accept_url'      => add_query_arg(
 					array(
-						'action' => 'reepay_finalize',
-						'key'    => $order->get_order_key(),
+						'action'    => 'reepay_finalize',
+						'key'       => $order->get_order_key(),
+						'_wpnonce'  => wp_create_nonce( 'reepay_finalize' ),
 					),
 					admin_url( 'admin-ajax.php' )
 				),

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -315,6 +315,13 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 	 * Ajax: Add Payment Method
 	 */
 	public function reepay_card_store() {
+		// Security: Verify nonce
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'reepay_add_card' ) ) {
+			wc_add_notice( __( 'Security check failed. Please try again.', 'reepay-checkout-gateway' ), 'error' );
+			wp_redirect( wc_get_account_endpoint_url( 'add-payment-method' ) );
+			exit();
+		}
+
 		$reepay_token    = isset( $_GET['payment_method'] ) ? wc_clean( $_GET['payment_method'] ) : '';
 		$current_user_id = get_current_user_id();
 

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -205,9 +205,16 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 
 		// Allow to pay exist orders by guests.
 		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) ) {
-			$order_id = wc_get_order_id_by_order_key( $_GET['key'] );
+			$order_id = wc_get_order_id_by_order_key( wc_clean( $_GET['key'] ) );
 			if ( $order_id ) {
 				$order = wc_get_order( $order_id );
+
+				// Security: Verify user ownership
+				if ( ! $order || ( $order->get_customer_id() && $order->get_customer_id() !== get_current_user_id() ) ) {
+					wc_add_notice( __( 'Invalid order.', 'reepay-checkout-gateway' ), 'error' );
+					wp_redirect( wc_get_account_endpoint_url( 'orders' ) );
+					exit();
+				}
 
 				// Get customer handle by order.
 				$gateway         = rp_get_payment_method( $order );

--- a/includes/Gateways/ReepayGateway.php
+++ b/includes/Gateways/ReepayGateway.php
@@ -209,7 +209,7 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 			if ( $order_id ) {
 				$order = wc_get_order( $order_id );
 
-				// Security: Verify user ownership
+				// Security: Verify user ownership.
 				if ( ! $order || ( $order->get_customer_id() && $order->get_customer_id() !== get_current_user_id() ) ) {
 					wc_add_notice( __( 'Invalid order.', 'reepay-checkout-gateway' ), 'error' );
 					wp_redirect( wc_get_account_endpoint_url( 'orders' ) );
@@ -322,7 +322,7 @@ abstract class ReepayGateway extends WC_Payment_Gateway {
 	 * Ajax: Add Payment Method
 	 */
 	public function reepay_card_store() {
-		// Security: Verify nonce
+		// Security: Verify nonce.
 		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'reepay_add_card' ) ) {
 			wc_add_notice( __( 'Security check failed. Please try again.', 'reepay-checkout-gateway' ), 'error' );
 			wp_redirect( wc_get_account_endpoint_url( 'add-payment-method' ) );

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -71,7 +71,7 @@ class OrderCapture {
 	 */
 	public function unset_specific_order_item_meta_data( array $formatted_meta, WC_Order_Item $item ): array {
 		// Only on emails notifications.
-		if ( is_admin() && isset( $_GET['post'] ) ) {
+		if ( is_admin() && isset( $_GET['post'] ) && current_user_can( 'edit_shop_orders' ) ) {
 			foreach ( $formatted_meta as $i => $meta ) {
 				if ( in_array( $meta->key, array( 'settled' ), true ) ) {
 					$meta->display_key = 'Settled';

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -223,8 +223,8 @@ class OrderCapture {
 			if ( ! rp_hpos_is_order_page() ) {
 				return;
 			}
-			$order_id      = absint( $_GET['id'] );
-			$nonce_action  = 'update-order_' . $order_id;
+			$order_id     = absint( isset( $_GET['id'] ) ? $_GET['id'] : 0 );
+			$nonce_action = 'update-order_' . $order_id;
 		} elseif ( ! isset( $_POST['post_type'] ) ||
 				'shop_order' !== $_POST['post_type'] ||
 				! isset( $_POST['post_ID'] ) ) {
@@ -270,7 +270,7 @@ class OrderCapture {
 			if ( ! rp_hpos_is_order_page() ) {
 				return;
 			}
-			$order_id     = absint( $_GET['id'] );
+			$order_id     = absint( isset( $_GET['id'] ) ? $_GET['id'] : 0 );
 			$nonce_action = 'update-order_' . $order_id;
 		} elseif ( ! isset( $_POST['post_type'] ) ||
 				'shop_order' !== $_POST['post_type'] ||

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -230,12 +230,12 @@ class OrderCapture {
 				return;
 		}
 
-		// Security: Verify nonce
+		// Security: Verify nonce.
 		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-post_' . $_POST['post_ID'] ) ) {
 			return;
 		}
 
-		// Security: Check user capability
+		// Security: Check user capability.
 		if ( ! current_user_can( 'edit_shop_orders' ) ) {
 			return;
 		}
@@ -272,12 +272,12 @@ class OrderCapture {
 				return;
 		}
 
-		// Security: Verify nonce for capture amount action
+		// Security: Verify nonce for capture amount action.
 		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'reepay_capture_amount_' . $_POST['post_ID'] ) ) {
 			return;
 		}
 
-		// Security: Check user capability
+		// Security: Check user capability.
 		if ( ! current_user_can( 'edit_shop_orders' ) ) {
 			return;
 		}

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -230,6 +230,16 @@ class OrderCapture {
 				return;
 		}
 
+		// Security: Verify nonce
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-post_' . $_POST['post_ID'] ) ) {
+			return;
+		}
+
+		// Security: Check user capability
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			return;
+		}
+
 		if ( ! isset( $_POST['line_item_capture'] ) && ! isset( $_POST['all_items_capture'] ) ) {
 			return;
 		}

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -223,15 +223,20 @@ class OrderCapture {
 			if ( ! rp_hpos_is_order_page() ) {
 				return;
 			}
+			$order_id      = absint( $_GET['id'] );
+			$nonce_action  = 'update-order_' . $order_id;
 		} elseif ( ! isset( $_POST['post_type'] ) ||
 				'shop_order' !== $_POST['post_type'] ||
 				! isset( $_POST['post_ID'] ) ) {
 
 				return;
+		} else {
+			$order_id     = absint( $_POST['post_ID'] );
+			$nonce_action = 'update-post_' . $order_id;
 		}
 
 		// Security: Verify nonce.
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-post_' . $_POST['post_ID'] ) ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), $nonce_action ) ) {
 			return;
 		}
 
@@ -244,7 +249,7 @@ class OrderCapture {
 			return;
 		}
 
-		$order = wc_get_order( $_POST['post_ID'] );
+		$order = wc_get_order( $order_id );
 
 		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
 			return;
@@ -265,15 +270,20 @@ class OrderCapture {
 			if ( ! rp_hpos_is_order_page() ) {
 				return;
 			}
+			$order_id     = absint( $_GET['id'] );
+			$nonce_action = 'update-order_' . $order_id;
 		} elseif ( ! isset( $_POST['post_type'] ) ||
 				'shop_order' !== $_POST['post_type'] ||
 				! isset( $_POST['post_ID'] ) ) {
 
 				return;
+		} else {
+			$order_id     = absint( $_POST['post_ID'] );
+			$nonce_action = 'update-post_' . $order_id;
 		}
 
 		// Security: Verify nonce for capture amount action.
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'reepay_capture_amount_' . $_POST['post_ID'] ) ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), $nonce_action ) ) {
 			return;
 		}
 
@@ -296,7 +306,7 @@ class OrderCapture {
 
 		$reepay_capture_amount_input = wc_format_decimal( $_POST['reepay_capture_amount_input'] );
 
-		$order = wc_get_order( $_POST['post_ID'] );
+		$order = wc_get_order( $order_id );
 
 		if ( ! rp_is_order_paid_via_reepay( $order ) ) {
 			return;

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -272,6 +272,16 @@ class OrderCapture {
 				return;
 		}
 
+		// Security: Verify nonce for capture amount action
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'reepay_capture_amount_' . $_POST['post_ID'] ) ) {
+			return;
+		}
+
+		// Security: Check user capability
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			return;
+		}
+
 		if ( ! isset( $_POST['reepay_capture_amount_button'] ) ) {
 			return;
 		}

--- a/includes/OrderFlow/Webhook.php
+++ b/includes/OrderFlow/Webhook.php
@@ -91,7 +91,18 @@ class Webhook {
 
 			$secret = $result['secret'];
 
-			set_transient( 'reepay_webhook_settings_secret', $secret, HOUR_IN_SECONDS );
+			/**
+			 * Cache webhook secret for 10 minutes to reduce API calls while limiting exposure window.
+			 * Note: For PCI DSS compliance in high-security environments, consider implementing
+			 * encryption at rest or disabling caching via the filter below.
+			 *
+			 * @param int $ttl Time to live in seconds. Default 600 (10 minutes). Set to 0 to disable caching.
+			 */
+			$cache_ttl = apply_filters( 'reepay_webhook_secret_cache_ttl', 10 * MINUTE_IN_SECONDS );
+
+			if ( $cache_ttl > 0 ) {
+				set_transient( 'reepay_webhook_settings_secret', $secret, $cache_ttl );
+			}
 		}
 
 		$check = bin2hex( hash_hmac( 'sha256', $data['timestamp'] . $data['id'], $secret, true ) );
@@ -101,7 +112,11 @@ class Webhook {
 			$result = reepay()->api( $this->logging_source )->request( 'GET', 'https://api.reepay.com/v1/account/webhook_settings' );
 			if ( ! is_wp_error( $result ) && ! empty( $result['secret'] ) ) {
 				$secret = $result['secret'];
-				set_transient( 'reepay_webhook_settings_secret', $secret, HOUR_IN_SECONDS );
+				// Use the same cache TTL as above for consistency.
+				$cache_ttl = apply_filters( 'reepay_webhook_secret_cache_ttl', 10 * MINUTE_IN_SECONDS );
+				if ( $cache_ttl > 0 ) {
+					set_transient( 'reepay_webhook_settings_secret', $secret, $cache_ttl );
+				}
 				$check = bin2hex( hash_hmac( 'sha256', $data['timestamp'] . $data['id'], $secret, true ) );
 			}
 

--- a/includes/OrderFlow/Webhook.php
+++ b/includes/OrderFlow/Webhook.php
@@ -411,14 +411,6 @@ class Webhook {
 						'',
 						$data['transaction']
 					);
-
-					// Force renewal orders to "completed" regardless of the status_settled setting.
-					if ( isset( $data['subscription'] ) ) {
-						$order = wc_get_order( $order->get_id() );
-						if ( $order && ! $order->has_status( 'completed' ) ) {
-							$order->update_status( 'completed', __( 'Renewal order completed via Frisbii.', 'reepay-checkout-gateway' ) );
-						}
-					}
 				} elseif ( function_exists( 'wc_get_logger' ) ) {
 					// Log to reepay_order_statuses log.
 					wc_get_logger()->debug(

--- a/includes/OrderFlow/Webhook.php
+++ b/includes/OrderFlow/Webhook.php
@@ -39,6 +39,30 @@ class Webhook {
 	}
 
 	/**
+	 * Filter sensitive data from arrays before logging.
+	 *
+	 * @param array $data Data to filter.
+	 *
+	 * @return array Filtered data.
+	 */
+	private function filter_sensitive_data( array $data ): array {
+		$sensitive_keys = array( 'card_number', 'cvv', 'cvc', 'masked_card', 'card_token', 'pan', 'secret', 'password', 'authorization' );
+		$filtered       = array();
+
+		foreach ( $data as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$filtered[ $key ] = $this->filter_sensitive_data( $value );
+			} elseif ( in_array( strtolower( $key ), $sensitive_keys, true ) ) {
+				$filtered[ $key ] = '***REDACTED***';
+			} else {
+				$filtered[ $key ] = $value;
+			}
+		}
+
+		return $filtered;
+	}
+
+	/**
 	 * WebHook Callback
 	 *
 	 * @return void
@@ -47,8 +71,8 @@ class Webhook {
 		http_response_code( 200 );
 
 		$raw_body = file_get_contents( 'php://input' );
-		$this->log( sprintf( 'WebHook: Initialized %s from %s', $_SERVER['REQUEST_URI'] ?? '', $_SERVER['REMOTE_ADDR'] ?? '' ) );
-		$this->log( sprintf( 'WebHook: Post data: %s', var_export( $raw_body, true ) ) ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		$this->log( sprintf( 'WebHook: Initialized %s from %s', sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ), sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) ) ) );
+		$this->log( sprintf( 'WebHook: Post data: %s', wp_json_encode( $this->filter_sensitive_data( json_decode( $raw_body, true ) ?: array() ) ) ) );
 		$data = json_decode( $raw_body, true );
 		if ( ! $data ) {
 			$this->log( 'WebHook: Error: Missing parameters' );
@@ -87,7 +111,7 @@ class Webhook {
 						'WebHook: Error: Signature verification failed. Event: %s, ID: %s, Remote IP: %s',
 						$data['event_type'] ?? 'unknown',
 						$data['id'] ?? 'unknown',
-						$_SERVER['REMOTE_ADDR'] ?? 'unknown'
+						sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? 'unknown' ) )
 					)
 				);
 
@@ -148,7 +172,7 @@ class Webhook {
 			sprintf(
 				'WebHook %1$s: Data: %2$s',
 				$data['event_type'],
-				var_export( $data, true ) //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+				wp_json_encode( $this->filter_sensitive_data( $data ) )
 			)
 		);
 

--- a/includes/Plugin/WoocommerceHPOS.php
+++ b/includes/Plugin/WoocommerceHPOS.php
@@ -26,11 +26,13 @@ class WoocommerceHPOS {
 	}
 
 	/**
-	 * Add notices
+	 * Declare compatibility with WooCommerce features.
 	 */
 	public function add_support() {
 		if ( class_exists( FeaturesUtil::class ) ) {
-			FeaturesUtil::declare_compatibility( 'custom_order_tables', reepay()->get_setting( 'plugin_file' ), true );
+			$plugin_file = reepay()->get_setting( 'plugin_file' );
+			FeaturesUtil::declare_compatibility( 'custom_order_tables', $plugin_file, true );
+			FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', $plugin_file, true );
 		}
 	}
 }

--- a/includes/Tokens/TokenReepay.php
+++ b/includes/Tokens/TokenReepay.php
@@ -222,7 +222,7 @@ class TokenReepay extends WC_Payment_Token_CC {
 		if ( rp_is_reepay_payment_method( $method['method']['gateway'] ) ) {
 			try {
 				$token = new TokenReepay( $method['method']['id'] );
-				echo $token->get_display_name();
+				echo esc_html( $token->get_display_name() );
 			} catch ( Exception $e ) {
 				_e( 'Token not found', 'reepay-checkout-gateway' );
 			}

--- a/includes/Tokens/TokenReepay.php
+++ b/includes/Tokens/TokenReepay.php
@@ -55,7 +55,7 @@ class TokenReepay extends WC_Payment_Token_CC {
 		$style = '';
 
 		if ( $this->get_card_type() === 'visa_dk' ) {
-			$style = 'style="width: 46px; height: 24px;"';
+			$style = 'width: 46px; height: 24px;';
 		}
 
 		// Security: Whitelist allowed card types to prevent path traversal.
@@ -70,12 +70,12 @@ class TokenReepay extends WC_Payment_Token_CC {
 		$reepay_logo_path = reepay()->get_setting( 'images_path' ) . $type . '.png';
 		if ( file_exists( $reepay_logo_path ) ) {
 			$img   = $reepay_logo_url;
-			$style = 'style="width: 46px; height: 24px;"';
+			$style = 'width: 46px; height: 24px;';
 		}
 
 		ob_start();
 		?>
-		<img <?php echo esc_attr( $style ); ?> src="<?php echo esc_url( $img ); ?>"
+		<img style="<?php echo esc_attr( $style ); ?>" src="<?php echo esc_url( $img ); ?>"
 									alt="<?php echo esc_attr( wc_get_credit_card_type_label( $this->get_card_type() ) ); ?>"/>
 		<?php echo esc_html( $this->get_masked_card() ); ?>
 		<?php echo esc_html( $this->get_expiry_month() . '/' . substr( $this->get_expiry_year(), 2 ) ); ?>
@@ -222,7 +222,7 @@ class TokenReepay extends WC_Payment_Token_CC {
 		if ( rp_is_reepay_payment_method( $method['method']['gateway'] ) ) {
 			try {
 				$token = new TokenReepay( $method['method']['id'] );
-				echo esc_html( $token->get_display_name() );
+				echo wp_kses_post( $token->get_display_name() );
 			} catch ( Exception $e ) {
 				_e( 'Token not found', 'reepay-checkout-gateway' );
 			}

--- a/includes/Tokens/TokenReepay.php
+++ b/includes/Tokens/TokenReepay.php
@@ -58,7 +58,7 @@ class TokenReepay extends WC_Payment_Token_CC {
 			$style = 'style="width: 46px; height: 24px;"';
 		}
 
-		// Security: Whitelist allowed card types to prevent path traversal
+		// Security: Whitelist allowed card types to prevent path traversal.
 		$allowed_types = array( 'visa', 'mastercard', 'amex', 'discover', 'jcb', 'maestro', 'dankort', 'diners', 'china_union_pay' );
 		$type          = strtolower( $this->get_card_type() );
 

--- a/includes/Tokens/TokenReepay.php
+++ b/includes/Tokens/TokenReepay.php
@@ -58,17 +58,38 @@ class TokenReepay extends WC_Payment_Token_CC {
 			$style = 'width: 46px; height: 24px;';
 		}
 
-		// Security: Whitelist allowed card types to prevent path traversal.
-		$allowed_types = array( 'visa', 'mastercard', 'amex', 'discover', 'jcb', 'maestro', 'dankort', 'diners', 'china_union_pay' );
+		// Map Reepay card type aliases to their image filenames (mirrors ReepayGateway::get_logo).
+		$card_type_map = array(
+			'visa'          => 'visa',
+			'visa_elec'     => 'visa-electron',
+			'visa-electron' => 'visa-electron',
+			'mc'            => 'mastercard',
+			'mastercard'    => 'mastercard',
+			'dankort'       => 'dankort',
+			'visa_dk'       => 'dankort',
+			'ffk'           => 'forbrugsforeningen',
+			'maestro'       => 'maestro',
+			'amex'          => 'american-express',
+			'diners'        => 'diners',
+			'discover'      => 'discover',
+			'jcb'           => 'jcb',
+			'china_union_pay' => 'cup',
+			'mobilepay'     => 'mobilepay',
+			'viabill'       => 'viabill',
+			'paypal'        => 'paypal',
+			'applepay'      => 'applepay',
+			'googlepay'     => 'googlepay',
+			'vipps'         => 'vipps',
+			'anyday'        => 'anyday',
+			'klarna_pay_later' => 'klarna',
+			'klarna_pay_now'   => 'klarna',
+		);
 		$type          = strtolower( $this->get_card_type() );
+		$image_name    = $card_type_map[ $type ] ?? null;
 
-		if ( ! in_array( $type, $allowed_types, true ) ) {
-			$type = 'default';
-		}
-
-		$reepay_logo_url  = reepay()->get_setting( 'images_url' ) . $type . '.png';
-		$reepay_logo_path = reepay()->get_setting( 'images_path' ) . $type . '.png';
-		if ( file_exists( $reepay_logo_path ) ) {
+		$reepay_logo_url  = $image_name ? reepay()->get_setting( 'images_url' ) . $image_name . '.png' : '';
+		$reepay_logo_path = $image_name ? reepay()->get_setting( 'images_path' ) . $image_name . '.png' : '';
+		if ( $image_name && file_exists( $reepay_logo_path ) ) {
 			$img   = $reepay_logo_url;
 			$style = 'width: 46px; height: 24px;';
 		}

--- a/includes/Tokens/TokenReepay.php
+++ b/includes/Tokens/TokenReepay.php
@@ -58,7 +58,14 @@ class TokenReepay extends WC_Payment_Token_CC {
 			$style = 'style="width: 46px; height: 24px;"';
 		}
 
-		$type             = $this->get_card_type();
+		// Security: Whitelist allowed card types to prevent path traversal
+		$allowed_types = array( 'visa', 'mastercard', 'amex', 'discover', 'jcb', 'maestro', 'dankort', 'diners', 'china_union_pay' );
+		$type          = strtolower( $this->get_card_type() );
+
+		if ( ! in_array( $type, $allowed_types, true ) ) {
+			$type = 'default';
+		}
+
 		$reepay_logo_url  = reepay()->get_setting( 'images_url' ) . $type . '.png';
 		$reepay_logo_path = reepay()->get_setting( 'images_path' ) . $type . '.png';
 		if ( file_exists( $reepay_logo_path ) ) {
@@ -68,8 +75,8 @@ class TokenReepay extends WC_Payment_Token_CC {
 
 		ob_start();
 		?>
-		<img <?php echo $style; ?> src="<?php echo $img; ?>"
-									alt="<?php echo wc_get_credit_card_type_label( $this->get_card_type() ); ?>"/>
+		<img <?php echo esc_attr( $style ); ?> src="<?php echo esc_url( $img ); ?>"
+									alt="<?php echo esc_attr( wc_get_credit_card_type_label( $this->get_card_type() ) ); ?>"/>
 		<?php echo esc_html( $this->get_masked_card() ); ?>
 		<?php echo esc_html( $this->get_expiry_month() . '/' . substr( $this->get_expiry_year(), 2 ) ); ?>
 

--- a/includes/Tokens/TokenReepayMS.php
+++ b/includes/Tokens/TokenReepayMS.php
@@ -93,7 +93,7 @@ class TokenReepayMS extends WC_Payment_Token {
 
 		if ( rp_is_reepay_payment_method( $method['method']['gateway'] ) ) {
 			$token = new TokenReepayMS( $method['method']['id'] );
-			echo esc_html( $token->get_display_name() );
+			echo wp_kses_post( $token->get_display_name() );
 		}
 	}
 }

--- a/includes/Tokens/TokenReepayMS.php
+++ b/includes/Tokens/TokenReepayMS.php
@@ -37,7 +37,7 @@ class TokenReepayMS extends WC_Payment_Token {
 		<img src="<?php echo esc_url( reepay()->get_setting( 'images_url' ) . 'mobilepay.png' ); ?>" width="46" height="24"/>
 
 		<?php if ( is_checkout() ) : ?>
-			<?php echo esc_html( '&nbsp;' . $this->get_token() ); ?>
+			<?php echo '&nbsp;' . esc_html( $this->get_token() ); ?>
 		<?php else : ?>
 			<?php
 			// translators: %s token.

--- a/includes/Tokens/TokenReepayVR.php
+++ b/includes/Tokens/TokenReepayVR.php
@@ -93,7 +93,7 @@ class TokenReepayVR extends WC_Payment_Token {
 
 		if ( rp_is_reepay_payment_method( $method['method']['gateway'] ) ) {
 			$token = new TokenReepayVR( $method['method']['id'] );
-			echo esc_html( $token->get_display_name() );
+			echo wp_kses_post( $token->get_display_name() );
 		}
 	}
 }

--- a/includes/Tokens/TokenReepayVR.php
+++ b/includes/Tokens/TokenReepayVR.php
@@ -37,7 +37,7 @@ class TokenReepayVR extends WC_Payment_Token {
 		<img src="<?php echo esc_url( reepay()->get_setting( 'images_url' ) . 'vipps.png' ); ?>" width="46" height="24"/>
 
 		<?php if ( is_checkout() ) : ?>
-			<?php echo esc_html( '&nbsp;' . $this->get_token() ); ?>
+			<?php echo '&nbsp;' . esc_html( $this->get_token() ); ?>
 		<?php else : ?>
 			<?php
 			// translators: %s token.

--- a/includes/Utils/ViteAssetsLoader.php
+++ b/includes/Utils/ViteAssetsLoader.php
@@ -24,6 +24,11 @@ class ViteAssetsLoader {
 	 * @return void
 	 */
 	public static function output_vite_dev( bool $admin_footer = true ): void {
+		// Security: Only load in development mode
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG || ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) {
+			return;
+		}
+
 		add_action(
 			$admin_footer ? 'admin_footer' : 'wp_footer',
 			function () {
@@ -61,6 +66,11 @@ class ViteAssetsLoader {
 	 * @return void
 	 */
 	public static function output_vite_dev_entry_point( string $entry_point, bool $admin_footer = true ): void {
+		// Security: Only load in development mode
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG || ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) {
+			return;
+		}
+
 		add_action(
 			$admin_footer ? 'admin_footer' : 'wp_footer',
 			function () use ( $entry_point ) {

--- a/includes/Utils/ViteAssetsLoader.php
+++ b/includes/Utils/ViteAssetsLoader.php
@@ -27,7 +27,7 @@ class ViteAssetsLoader {
 		add_action(
 			$admin_footer ? 'admin_footer' : 'wp_footer',
 			function () {
-				$host = self::HMR_HOST;
+				$host = esc_url( self::HMR_HOST );
 				// phpcs:disable
 				$scripts = <<<HTML
 					<script type="module">
@@ -40,7 +40,14 @@ class ViteAssetsLoader {
 					<script src="{$host}/@vite/client" type="module"></script>
 				HTML;
 				// phpcs:enable
-				echo $scripts;
+				
+				$allowed_html = array(
+					'script' => array(
+						'type' => array(),
+						'src' => array()
+					)
+				);
+				echo wp_kses( $scripts, $allowed_html );
 			}
 		);
 	}
@@ -57,13 +64,21 @@ class ViteAssetsLoader {
 		add_action(
 			$admin_footer ? 'admin_footer' : 'wp_footer',
 			function () use ( $entry_point ) {
-				$host = self::HMR_HOST;
+				$host = esc_url( self::HMR_HOST );
+				$entry_point = esc_attr( $entry_point );
 				// phpcs:disable
 				$scripts = <<<HTML
 					<script src="{$host}/{$entry_point}" type="module"></script>
 				HTML;
 				// phpcs:enable
-				echo $scripts;
+				
+				$allowed_html = array(
+					'script' => array(
+						'type' => array(),
+						'src' => array()
+					)
+				);
+				echo wp_kses( $scripts, $allowed_html );
 			}
 		);
 	}

--- a/includes/Utils/ViteAssetsLoader.php
+++ b/includes/Utils/ViteAssetsLoader.php
@@ -45,12 +45,12 @@ class ViteAssetsLoader {
 					<script src="{$host}/@vite/client" type="module"></script>
 				HTML;
 				// phpcs:enable
-				
+
 				$allowed_html = array(
 					'script' => array(
 						'type' => array(),
-						'src' => array()
-					)
+						'src'  => array(),
+					),
 				);
 				echo wp_kses( $scripts, $allowed_html );
 			}
@@ -74,19 +74,19 @@ class ViteAssetsLoader {
 		add_action(
 			$admin_footer ? 'admin_footer' : 'wp_footer',
 			function () use ( $entry_point ) {
-				$host = esc_url( self::HMR_HOST );
+				$host        = esc_url( self::HMR_HOST );
 				$entry_point = esc_attr( $entry_point );
 				// phpcs:disable
 				$scripts = <<<HTML
 					<script src="{$host}/{$entry_point}" type="module"></script>
 				HTML;
 				// phpcs:enable
-				
+
 				$allowed_html = array(
 					'script' => array(
 						'type' => array(),
-						'src' => array()
-					)
+						'src'  => array(),
+					),
 				);
 				echo wp_kses( $scripts, $allowed_html );
 			}

--- a/includes/Utils/ViteAssetsLoader.php
+++ b/includes/Utils/ViteAssetsLoader.php
@@ -24,7 +24,7 @@ class ViteAssetsLoader {
 	 * @return void
 	 */
 	public static function output_vite_dev( bool $admin_footer = true ): void {
-		// Security: Only load in development mode
+		// Security: Only load in development mode.
 		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG || ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) {
 			return;
 		}
@@ -66,7 +66,7 @@ class ViteAssetsLoader {
 	 * @return void
 	 */
 	public static function output_vite_dev_entry_point( string $entry_point, bool $admin_footer = true ): void {
-		// Security: Only load in development mode
+		// Security: Only load in development mode.
 		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG || ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) {
 			return;
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "reepay-woocommerce-payment",
-  "version": "1.0.0",
+  "version": "1.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reepay-woocommerce-payment",
-      "version": "1.0.0",
+      "version": "1.8.12",
       "license": "SEE LICENSE IN License.txt",
       "dependencies": {
-        "archiver": "^7.0.1",
         "gulp-clean-css": "^4.3.0",
         "gulp-postcss": "^10.0.0",
         "gulp-sass": "^5.0.0",
@@ -48,73 +47,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -478,9 +410,9 @@
       }
     },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -489,28 +421,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
       }
     },
     "node_modules/acorn": {
@@ -585,42 +495,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -668,12 +542,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/async-done": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-2.0.0.tgz",
@@ -706,6 +574,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -735,12 +604,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -755,6 +626,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -812,9 +684,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -839,6 +711,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -857,15 +730,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -1067,22 +931,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1115,46 +963,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/detect-file": {
       "version": "1.0.0",
@@ -1219,12 +1029,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1250,28 +1054,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -1326,6 +1113,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -1437,22 +1225,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fork-stream": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
@@ -1521,27 +1293,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -1666,6 +1417,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/gulp": {
@@ -1808,19 +1560,6 @@
         "minimatch": "^3.0.3"
       }
     },
-    "node_modules/gulp-match/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/gulp-postcss": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-10.0.0.tgz",
@@ -1958,6 +1697,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1975,9 +1715,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1985,6 +1725,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -2146,18 +1887,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -2195,12 +1924,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -2210,21 +1941,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jsonfile": {
@@ -2248,48 +1964,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/lead": {
@@ -2333,23 +2007,11 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
     },
     "node_modules/map-cache": {
       "version": "0.2.2",
@@ -2383,48 +2045,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "*"
       }
     },
     "node_modules/mute-stdout": {
@@ -2467,6 +2097,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2531,12 +2162,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -2560,15 +2185,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
@@ -2601,22 +2217,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2624,9 +2224,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2718,66 +2318,12 @@
         }
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.7.tgz",
-      "integrity": "sha512-FjiwU9HaHW6YB3H4a1sFudnv93lvydNjz2lmyUXR6IwKhGI+bgL3SOZrBGn6kvvX2pJvhEkGSGjyTHN47O4rqA==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -2903,6 +2449,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3001,39 +2548,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3102,6 +2616,7 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
       "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -3113,6 +2628,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -3132,35 +2648,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3206,17 +2694,6 @@
       "license": "MIT",
       "optionalDependencies": {
         "semver": "^6.3.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
       }
     },
     "node_modules/teex": {
@@ -3265,6 +2742,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -3371,6 +2849,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8flags": {
@@ -3545,118 +3024,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3674,9 +3041,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -3713,20 +3080,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "reepay-woocommerce-payment",
-  "version": "1.0.0",
+  "version": "1.8.12",
   "description": "",
   "main": "gulpfile.js",
   "dependencies": {
-    "archiver": "^7.0.1",
     "gulp-clean-css": "^4.3.0",
     "gulp-postcss": "^10.0.0",
     "gulp-sass": "^5.0.0",

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,7 +4,7 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Frisbii
  * Author URI: https://frisbii.com
- * Version: 1.8.11.1
+ * Version: 1.8.12
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,7 +4,7 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Frisbii
  * Author URI: https://frisbii.com
- * Version: 1.8.11
+ * Version: 1.8.11.1
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -106,14 +106,16 @@ class WC_ReepayCheckout {
 		if ( true === $instance_requested && is_null( self::$instance ) ) {
 			$message = 'Function Frisbii Pay called in time of initialization main plugin class. Recursion prevented';
 
+			// Security: Log stack trace to file instead of displaying to users
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				$message .= '<br>Stack trace for debugging:<br><pre>' . print_r( //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				error_log( 'Reepay Plugin Initialization Error: ' . print_r( //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 					debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ), //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 					true
-				) . '</pre>';
+				) );
 			}
 
-			wp_die( wp_kses_post( $message ) );
+			// Security: Display generic error message to users
+			wp_die( esc_html__( 'Plugin initialization error. Please contact support.', 'reepay-checkout-gateway' ) );
 		}
 
 		$instance_requested = true;

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -33,6 +33,7 @@
         <properties>
             <property name="custom_capabilities" type="array">
                 <element value="manage_woocommerce"/>
+                <element value="edit_shop_orders"/>
             </property>
         </properties>
     </rule>

--- a/templates/admin/admin-options.php
+++ b/templates/admin/admin-options.php
@@ -13,8 +13,8 @@ use Reepay\Checkout\Gateways\ReepayGateway;
 defined( 'ABSPATH' ) || exit();
 ?>
 
-<h2><?php esc_html( $gateway->get_method_title() ); ?></h2>
-<?php wp_kses_post( wpautop( $gateway->get_method_description() ) ); ?>
+<h2><?php echo esc_html( $gateway->get_method_title() ); ?></h2>
+<?php echo wp_kses_post( wpautop( $gateway->get_method_description() ) ); ?>
 <p><?php _e( 'Frisbii Pay', 'reepay-checkout-gateway' ); ?></p>
 <?php if ( ! $webhook_installed ) : ?>
 	<p>

--- a/templates/admin/capture-item-button.php
+++ b/templates/admin/capture-item-button.php
@@ -15,8 +15,8 @@ defined( 'ABSPATH' ) || exit();
 <button
 	type="submit"
 	class="button save_order button-primary capture-item-button"
-	name="<?php echo $name; ?>"
-	value="<?php echo $value; ?>"
+	name="<?php echo esc_attr( $name ); ?>"
+	value="<?php echo esc_attr( $value ); ?>"
 >
-	<?php echo $text; ?>
+	<?php echo esc_html( $text ); ?>
 </button>

--- a/templates/admin/capture-item-button.php
+++ b/templates/admin/capture-item-button.php
@@ -18,5 +18,5 @@ defined( 'ABSPATH' ) || exit();
 	name="<?php echo esc_attr( $name ); ?>"
 	value="<?php echo esc_attr( $value ); ?>"
 >
-	<?php echo esc_html( $text ); ?>
+	<?php echo wp_kses_post( $text ); ?>
 </button>

--- a/templates/admin/payment-actions.php
+++ b/templates/admin/payment-actions.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit();
 	<?php if ( $gateway->can_capture( $order ) ) : ?>
 		<button id="reepay_capture"
 				data-nonce="<?php echo wp_create_nonce( 'reepay' ); ?>"
-				data-order-id="<?php echo esc_html( $order->get_id() ); ?>">
+				data-order-id="<?php echo esc_attr( $order->get_id() ); ?>">
 			<?php _e( 'Capture Payment', 'reepay-checkout-gateway' ); ?>
 		</button>
 	<?php endif; ?>
@@ -26,7 +26,7 @@ defined( 'ABSPATH' ) || exit();
 	<?php if ( $gateway->can_cancel( $order ) ) : ?>
 		<button id="reepay_cancel"
 				data-nonce="<?php echo wp_create_nonce( 'reepay' ); ?>"
-				data-order-id="<?php echo esc_html( $order->get_id() ); ?>">
+				data-order-id="<?php echo esc_attr( $order->get_id() ); ?>">
 			<?php _e( 'Cancel Payment', 'reepay-checkout-gateway' ); ?>
 		</button>
 	<?php endif; ?>

--- a/templates/checkout/gateway-logos.php
+++ b/templates/checkout/gateway-logos.php
@@ -15,8 +15,8 @@ defined( 'ABSPATH' ) || exit();
 	<?php foreach ( $logos as $logo ) : ?>
 	<li class="reepay-logo">
 		<img
-			src="<?php echo $logo['src']; ?>"
-			alt="<?php echo $logo['alt']; ?>"
+			src="<?php echo esc_url( $logo['src'] ); ?>"
+			alt="<?php echo esc_attr( $logo['alt'] ); ?>"
 		>
 	</li>
 	<?php endforeach; ?>

--- a/templates/checkout/order-details.php
+++ b/templates/checkout/order-details.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit();
 		<?php esc_html_e( 'Order number:', 'reepay-checkout-gateway' ); ?>
 		<strong>
 		<?php
-		echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo esc_html( $order->get_order_number() );
 		?>
 			</strong>
 	</li>
@@ -34,7 +34,7 @@ defined( 'ABSPATH' ) || exit();
 	<?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
 		<li class="woocommerce-order-overview__email email">
 			<?php esc_html_e( 'Email:', 'reepay-checkout-gateway' ); ?>
-			<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+			<strong><?php echo esc_html( $order->get_billing_email() ); ?></strong>
 		</li>
 	<?php endif; ?>
 

--- a/templates/meta-boxes/customer.php
+++ b/templates/meta-boxes/customer.php
@@ -14,16 +14,16 @@ defined( 'ABSPATH' ) || exit;
 		<?php _e( 'Handle', 'reepay-checkout-gateway' ); ?>
 	</li>
 	<li class="reepay-admin-section-li-small">
-		<?php echo $args['handle']; ?>
+		<?php echo esc_html( $args['handle'] ); ?>
 	</li>
 	<li class="reepay-admin-section-li-header-small">
 		<?php _e( 'Email', 'reepay-checkout-gateway' ); ?>
 	</li>
 	<li class="reepay-admin-section-li-small">
-		<?php echo $args['email']; ?>
+		<?php echo esc_html( $args['email'] ); ?>
 	</li>
 	<li class="reepay-admin-section-li">
-		<a class="button" href="<?php echo $args['link']; ?>" target="_blank">
+		<a class="button" href="<?php echo esc_url( $args['link'] ); ?>" target="_blank">
 			<?php _e( 'See customer', 'reepay-checkout-gateway' ); ?>
 		</a>
 	</li>

--- a/templates/meta-boxes/invoice.php
+++ b/templates/meta-boxes/invoice.php
@@ -23,22 +23,22 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 ?>
 
 <ul class="order_action order_action_reepay_subscriotions clearfix">
-	<input type="hidden" id="reepay_currency" value="<?php echo get_woocommerce_currency_symbol( $order->get_currency() ); ?>">
-	<input type="hidden" id="reepay_order_id" data-order-id="<?php echo $order_id; ?>"/>
-	<input type="hidden" id="reepay_order_total_authorized" value="<?php echo $order_data['authorized_amount']; ?>" data-initial-amount="<?php echo rp_make_initial_amount( $order_data['authorized_amount'], $order->get_currency() ); ?>" />
-	<input type="hidden" id="reepay_order_total_settled" value="<?php echo $order_data['settled_amount']; ?>" data-initial-amount="<?php echo rp_make_initial_amount( $order_data['settled_amount'], $order->get_currency() ); ?>" />
-	<input type="hidden" id="reepay_order_total" data-order-total="<?php echo $order->get_total(); ?>" value="<?php echo $order->get_total() . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ); ?>"/>
+	<input type="hidden" id="reepay_currency" value="<?php echo esc_attr( get_woocommerce_currency_symbol( $order->get_currency() ) ); ?>">
+	<input type="hidden" id="reepay_order_id" data-order-id="<?php echo esc_attr( $order_id ); ?>"/>
+	<input type="hidden" id="reepay_order_total_authorized" value="<?php echo esc_attr( $order_data['authorized_amount'] ); ?>" data-initial-amount="<?php echo esc_attr( rp_make_initial_amount( $order_data['authorized_amount'], $order->get_currency() ) ); ?>" />
+	<input type="hidden" id="reepay_order_total_settled" value="<?php echo esc_attr( $order_data['settled_amount'] ); ?>" data-initial-amount="<?php echo esc_attr( rp_make_initial_amount( $order_data['settled_amount'], $order->get_currency() ) ); ?>" />
+	<input type="hidden" id="reepay_order_total" data-order-total="<?php echo esc_attr( $order->get_total() ); ?>" value="<?php echo esc_attr( $order->get_total() . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ) ); ?>"/>
 	<li class="reepay-admin-section-li-header-small">
 		<?php echo __( 'Invoice handle', 'reepay-checkout-gateway' ); ?>
 	</li>
 	<li class="reepay-admin-section-li-small">
-		<?php echo $order_data['handle']; ?>
+		<?php echo esc_html( $order_data['handle'] ); ?>
 	</li>
 
 	<li class="reepay-admin-section-li-header-small">
 		<?php echo __( 'State', 'reepay-checkout-gateway' ); ?>
 	</li>
-	<li class="reepay-admin-section-li-small reepay-invoice-status reepay-invoice-status-<?php echo $order_data['state']; ?> ">
+	<li class="reepay-admin-section-li-small reepay-invoice-status reepay-invoice-status-<?php echo esc_attr( $order_data['state'] ); ?> ">
 		<?php echo ucfirst( $order_data['state'] ); ?>
 	</li>
 	<?php if ( $order_is_cancelled ) : ?>
@@ -54,7 +54,7 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 		<li class="reepay-admin-section-li-small" style="display: flex;  align-items: center;">
 			<?php if ( isset( $card_logo ) ) : ?>
 				<img style="max-width: 70px; margin-right: 0"
-					src="<?php echo $card_logo; ?>"
+					src="<?php echo esc_url( $card_logo ); ?>"
 					class="reepay-admin-card-logo"/>
 			<?php endif; ?>
 			<?php echo esc_html( rp_format_credit_card( $order_data['transactions'][0]['card_transaction']['masked_card'] ) ); ?>
@@ -63,7 +63,7 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 
 	<?php if ( isset( $order_data['transactions'][0]['mps_transaction'] ) ) : ?>
 		<div style="text-align: center;">
-			<img src="<?php echo $gateway->get_logo( 'ms_subscripiton' ); ?>" class="reepay-admin-card-logo"/>
+			<img src="<?php echo esc_url( $gateway->get_logo( 'ms_subscripiton' ) ); ?>" class="reepay-admin-card-logo"/>
 		</div>
 	<?php endif; ?>
 
@@ -75,7 +75,7 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 			<span class='reepay-balance__currency'>
 				&nbsp;
 			</span>
-			<?php echo $order_data['authorized_amount'] ? rp_make_initial_amount( $order_data['authorized_amount'] - $order_data['settled_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ) : $order_data['authorized_amount'] . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ); ?>
+			<?php echo esc_html( $order_data['authorized_amount'] ? rp_make_initial_amount( $order_data['authorized_amount'] - $order_data['settled_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ) : $order_data['authorized_amount'] . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ) ); ?>
 		</span>
 	</li>
 	<li class="reepay-admin-section-li">
@@ -86,7 +86,7 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 			<span class='reepay-balance__currency'>
 				&nbsp;
 			</span>
-			<?php echo rp_make_initial_amount( $order_data['authorized_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ); ?>
+			<?php echo esc_html( rp_make_initial_amount( $order_data['authorized_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ) ); ?>
 		</span>
 	</li>
 
@@ -98,7 +98,7 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 			<span class='reepay-balance__currency'>
 				&nbsp;
 			</span>
-			<?php echo rp_make_initial_amount( $order_data['settled_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ); ?>
+			<?php echo esc_html( rp_make_initial_amount( $order_data['settled_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ) ); ?>
 		</span>
 	</li>
 	<li class="reepay-admin-section-li">
@@ -109,7 +109,7 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 			<span class='reepay-balance__currency'>
 				&nbsp;
 			</span>
-			<?php echo rp_make_initial_amount( $order_data['refunded_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ); ?>
+			<?php echo esc_html( rp_make_initial_amount( $order_data['refunded_amount'], $order_data['currency'] ) . ' ' . get_woocommerce_currency_symbol( $order->get_currency() ) ); ?>
 		</span>
 	</li>
 	<?php
@@ -122,7 +122,7 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 				<?php echo esc_html__( 'Capture amount', 'reepay-checkout-gateway' ); ?>:
 			</span>
 			<span class="reepay-balance__amount reepay-balance__capture-amount-input">
-				<input type="text" id="reepay-capture-amount-input" name="reepay_capture_amount_input" class="capture-amount-input" value="<?php echo $capture_amount_format; ?>" />&nbsp;&nbsp;<?php echo get_woocommerce_currency_symbol( $order->get_currency() ); ?>
+				<input type="text" id="reepay-capture-amount-input" name="reepay_capture_amount_input" class="capture-amount-input" value="<?php echo esc_attr( $capture_amount_format ); ?>" />&nbsp;&nbsp;<?php echo esc_html( get_woocommerce_currency_symbol( $order->get_currency() ) ); ?>
 			</span>
 		</li>
 		<li class="reepay-admin-section-li-small">
@@ -135,8 +135,8 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 	?>
 
 	<li class="reepay-admin-section-li-small" style="margin-top: 15px;">
-		<a class="button" href="<?php echo $link; ?>" target="_blank">
-			<?php _e( 'See invoice', 'reepay-checkout-gateway' ); ?>
+		<a class="button" href="<?php echo esc_url( $link ); ?>" target="_blank">
+			<?php esc_html_e( 'See invoice', 'reepay-checkout-gateway' ); ?>
 		</a>
 	</li>
 </ul>

--- a/templates/meta-boxes/invoice.php
+++ b/templates/meta-boxes/invoice.php
@@ -117,10 +117,6 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 	if ( $capture_amount > 0 ) {
 		$capture_amount_format = $capture_amount;
 		?>
-		<?php
-		// Security: Add nonce field for capture amount action.
-		wp_nonce_field( 'reepay_capture_amount_' . $order_id, '_wpnonce' );
-		?>
 		<li class="reepay-admin-section-li">
 			<span class="reepay-balance__label reepay-balance__capture-amount">
 				<?php echo esc_html__( 'Capture amount', 'reepay-checkout-gateway' ); ?>:

--- a/templates/meta-boxes/invoice.php
+++ b/templates/meta-boxes/invoice.php
@@ -117,9 +117,9 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 	if ( $capture_amount > 0 ) {
 		$capture_amount_format = $capture_amount;
 		?>
-		<?php 
+		<?php
 		// Security: Add nonce field for capture amount action
-		wp_nonce_field( 'reepay_capture_amount_' . $order_id, '_wpnonce' ); 
+		wp_nonce_field( 'reepay_capture_amount_' . $order_id, '_wpnonce' );
 		?>
 		<li class="reepay-admin-section-li">
 			<span class="reepay-balance__label reepay-balance__capture-amount">

--- a/templates/meta-boxes/invoice.php
+++ b/templates/meta-boxes/invoice.php
@@ -117,6 +117,10 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 	if ( $capture_amount > 0 ) {
 		$capture_amount_format = $capture_amount;
 		?>
+		<?php 
+		// Security: Add nonce field for capture amount action
+		wp_nonce_field( 'reepay_capture_amount_' . $order_id, '_wpnonce' ); 
+		?>
 		<li class="reepay-admin-section-li">
 			<span class="reepay-balance__label reepay-balance__capture-amount">
 				<?php echo esc_html__( 'Capture amount', 'reepay-checkout-gateway' ); ?>:

--- a/templates/meta-boxes/invoice.php
+++ b/templates/meta-boxes/invoice.php
@@ -118,7 +118,7 @@ if ( ! empty( $order_data['transactions'][0] ) && ! empty( $order_data['transact
 		$capture_amount_format = $capture_amount;
 		?>
 		<?php
-		// Security: Add nonce field for capture amount action
+		// Security: Add nonce field for capture amount action.
 		wp_nonce_field( 'reepay_capture_amount_' . $order_id, '_wpnonce' );
 		?>
 		<li class="reepay-admin-section-li">

--- a/templates/meta-boxes/meta-fields.php
+++ b/templates/meta-boxes/meta-fields.php
@@ -9,4 +9,4 @@
 
 defined( 'ABSPATH' ) || exit;
 ?>
-<div class="billwerk-meta-fields" data-post-type="<?php echo $args['post_type']; ?>"></div>
+<div class="billwerk-meta-fields" data-post-type="<?php echo esc_attr( $args['post_type'] ); ?>"></div>

--- a/templates/meta-boxes/plan.php
+++ b/templates/meta-boxes/plan.php
@@ -14,16 +14,16 @@ defined( 'ABSPATH' ) || exit;
 		<?php _e( 'Handle', 'reepay-checkout-gateway' ); ?>
 	</li>
 	<li class="reepay-admin-section-li-small">
-		<?php echo $args['handle']; ?>
+		<?php echo esc_html( $args['handle'] ); ?>
 	</li>
 	<li class="reepay-admin-section-li-header-small">
 		<?php _e( 'Plan', 'reepay-checkout-gateway' ); ?>
 	</li>
 	<li class="reepay-admin-section-li-small">
-		<?php echo $args['plan']; ?>
+		<?php echo esc_html( $args['plan'] ); ?>
 	</li>
 	<li class="reepay-admin-section-li">
-		<a class="button" href="<?php echo $args['link']; ?>" target="_blank">
+		<a class="button" href="<?php echo esc_url( $args['link'] ); ?>" target="_blank">
 			<?php _e( 'See subscription', 'reepay-checkout-gateway' ); ?>
 		</a>
 	</li>

--- a/tests/unit/orderFlow/OrderCaptureTest.php
+++ b/tests/unit/orderFlow/OrderCaptureTest.php
@@ -210,9 +210,15 @@ class OrderCaptureTest extends Reepay_UnitTestCase {
 
 		$this->order_generator->order()->save();
 
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->order_generator->order()->get_id();
+
 		$_POST['line_item_capture'] = $order_item_id;
-		$_GET['id']                 = $this->order_generator->order()->get_id();
-		$_POST['post_ID']           = $this->order_generator->order()->get_id();
+		$_GET['id']                 = $post_id;
+		$_POST['post_ID']           = $post_id;
+		$_POST['_wpnonce']          = wp_create_nonce( 'update-post_' . $post_id );
 
 		if ( HPOS_STATE::is_active() ) {
 			set_current_screen( 'edit-post' );
@@ -288,9 +294,15 @@ class OrderCaptureTest extends Reepay_UnitTestCase {
 
 		$this->order_generator->order()->save();
 
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->order_generator->order()->get_id();
+
 		$_POST['all_items_capture'] = 'true';
-		$_GET['id']                 = $this->order_generator->order()->get_id();
-		$_POST['post_ID']           = $this->order_generator->order()->get_id();
+		$_GET['id']                 = $post_id;
+		$_POST['post_ID']           = $post_id;
+		$_POST['_wpnonce']          = wp_create_nonce( 'update-post_' . $post_id );
 
 		if ( HPOS_STATE::is_active() ) {
 			set_current_screen( 'edit-post' );

--- a/tests/unit/orderFlow/OrderCaptureTest.php
+++ b/tests/unit/orderFlow/OrderCaptureTest.php
@@ -218,7 +218,7 @@ class OrderCaptureTest extends Reepay_UnitTestCase {
 		$_POST['line_item_capture'] = $order_item_id;
 		$_GET['id']                 = $post_id;
 		$_POST['post_ID']           = $post_id;
-		$_POST['_wpnonce']          = wp_create_nonce( 'update-post_' . $post_id );
+		$_POST['_wpnonce']          = wp_create_nonce( ( HPOS_STATE::is_active() ? 'update-order_' : 'update-post_' ) . $post_id );
 
 		if ( HPOS_STATE::is_active() ) {
 			set_current_screen( 'edit-post' );
@@ -302,7 +302,7 @@ class OrderCaptureTest extends Reepay_UnitTestCase {
 		$_POST['all_items_capture'] = 'true';
 		$_GET['id']                 = $post_id;
 		$_POST['post_ID']           = $post_id;
-		$_POST['_wpnonce']          = wp_create_nonce( 'update-post_' . $post_id );
+		$_POST['_wpnonce']          = wp_create_nonce( ( HPOS_STATE::is_active() ? 'update-order_' : 'update-post_' ) . $post_id );
 
 		if ( HPOS_STATE::is_active() ) {
 			set_current_screen( 'edit-post' );

--- a/vite/package-lock.json
+++ b/vite/package-lock.json
@@ -1,19 +1,19 @@
 {
-    "name": "react",
-    "version": "0.0.0",
+    "name": "reepay-woocommerce-payment-react",
+    "version": "1.8.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "react",
-            "version": "0.0.0",
+            "name": "reepay-woocommerce-payment-react",
+            "version": "1.8.12",
             "dependencies": {
                 "-": "^0.0.1",
                 "@babel/runtime": "^7.27.0",
                 "@codemirror/lang-php": "^6.0.1",
                 "@hookform/resolvers": "^3.3.4",
-                "@monaco-editor/loader": "^1.4.0",
-                "@monaco-editor/react": "^4.6.0",
+                "@monaco-editor/loader": "^1.7.0",
+                "@monaco-editor/react": "^4.7.0",
                 "@rematch/core": "^2.2.0",
                 "@rematch/immer": "^2.1.3",
                 "@rematch/loading": "^2.1.2",
@@ -24,11 +24,12 @@
                 "brace-expansion": ">=2.0.2",
                 "braces": "^3.0.3",
                 "clsx": "^2.1.1",
+                "dompurify": ">=3.4.0",
                 "glob": ">=10.5.0",
                 "immer": "^9.0.21",
                 "js-yaml": ">=4.1.1",
                 "localforage": "^1.10.0",
-                "lodash": "^4.17.23",
+                "lodash": "^4.18.0",
                 "micromatch": "^4.0.8",
                 "moment": "^2.30.1",
                 "react": "^18.2.0",
@@ -50,8 +51,9 @@
                 "@vitejs/plugin-react-swc": "^3.5.0",
                 "@wordpress/i18n": "^4.57.0",
                 "autoprefixer": "^10.4.19",
-                "axios": "^1.13.5",
+                "axios": "^1.15.0",
                 "brace-expansion": "^2.0.2",
+                "dompurify": ">=3.4.0",
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-jsx-a11y": "^6.8.0",
@@ -66,11 +68,8 @@
                 "prettier-plugin-tailwindcss": "^0.5.14",
                 "tailwindcss": "^3.4.3",
                 "typescript": "^5.2.2",
-                "vite": "^6.4.1",
+                "vite": "^6.4.2",
                 "vite-plugin-monaco-editor": "^1.1.0"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-linux-x64-gnu": "4.9.5"
             }
         },
         "node_modules/-": {
@@ -1265,19 +1264,6 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
-            "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.59.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
@@ -1709,8 +1695,7 @@
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/@types/use-sync-external-store": {
             "version": "0.0.6",
@@ -2402,15 +2387,15 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+            "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/axobject-query": {
@@ -2972,11 +2957,11 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-            "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+            "dev": true,
             "license": "(MPL-2.0 OR Apache-2.0)",
-            "peer": true,
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -3651,16 +3636,16 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {
@@ -4807,9 +4792,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
@@ -4917,12 +4902,12 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-            "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -4941,9 +4926,9 @@
             }
         },
         "node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-            "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -4978,8 +4963,18 @@
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "dompurify": "3.2.7",
+                "dompurify": "3.4.0",
                 "marked": "14.0.0"
+            }
+        },
+        "node_modules/monaco-editor/node_modules/dompurify": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "peer": true,
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/ms": {
@@ -5349,9 +5344,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -5687,11 +5682,14 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -6787,9 +6785,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7060,9 +7058,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7163,9 +7161,9 @@
             }
         },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/vite/package.json
+++ b/vite/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "react",
+    "name": "reepay-woocommerce-payment-react",
     "private": true,
-    "version": "0.0.0",
+    "version": "1.8.12",
     "type": "module",
     "scripts": {
         "dev:meta-fields": "vite -c vite.config.meta-fields.ts",
@@ -15,8 +15,8 @@
         "@babel/runtime": "^7.27.0",
         "@codemirror/lang-php": "^6.0.1",
         "@hookform/resolvers": "^3.3.4",
-        "@monaco-editor/loader": "^1.4.0",
-        "@monaco-editor/react": "^4.6.0",
+        "@monaco-editor/loader": "^1.7.0",
+        "@monaco-editor/react": "^4.7.0",
         "@rematch/core": "^2.2.0",
         "@rematch/immer": "^2.1.3",
         "@rematch/loading": "^2.1.2",
@@ -24,14 +24,15 @@
         "@types/uuid": "^9.0.8",
         "@uiw/codemirror-theme-github": "^4.22.0",
         "@uiw/react-codemirror": "^4.22.0",
-        "braces": "^3.0.3",
         "brace-expansion": ">=2.0.2",
+        "braces": "^3.0.3",
         "clsx": "^2.1.1",
+        "dompurify": ">=3.4.0",
         "glob": ">=10.5.0",
         "immer": "^9.0.21",
         "js-yaml": ">=4.1.1",
         "localforage": "^1.10.0",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.0",
         "micromatch": "^4.0.8",
         "moment": "^2.30.1",
         "react": "^18.2.0",
@@ -53,15 +54,16 @@
         "@vitejs/plugin-react-swc": "^3.5.0",
         "@wordpress/i18n": "^4.57.0",
         "autoprefixer": "^10.4.19",
-        "axios": "^1.13.5",
-        "form-data": "^4.0.4",
+        "axios": "^1.15.0",
         "brace-expansion": "^2.0.2",
+        "dompurify": ">=3.4.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
+        "form-data": "^4.0.4",
         "glob": "^13.0.0",
         "js-yaml": ">=4.1.1",
         "postcss": "^8.4.49",
@@ -69,13 +71,10 @@
         "prettier-plugin-tailwindcss": "^0.5.14",
         "tailwindcss": "^3.4.3",
         "typescript": "^5.2.2",
-        "vite": "^6.4.1",
+        "vite": "^6.4.2",
         "vite-plugin-monaco-editor": "^1.1.0"
     },
     "overrides": {
         "minimatch": ">=10.2.1"
-    },
-    "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.9.5"
     }
 }


### PR DESCRIPTION
v 1.8.12
- [Fix] - Setting "Status: Frisbii Pay Settled" applies to Subscription renewal orders.
- [Fix] - Adds compatibility declaration for WooCommerce Blocks checkout.
- [Improvement] - General security patches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment capture/refund/cancel paths, webhook processing/logging, and order-status transitions, so regressions could impact checkout or post-payment flows despite changes being mostly validation and sanitization.
> 
> **Overview**
> Updates the plugin to `1.8.12` and **hardens several security-sensitive entry points**: admin AJAX capture/cancel/refund now validates nonces, order existence, and that the order was paid via Reepay; checkout/account flows add nonces and ownership checks when finalizing payment, adding cards, and deleting saved payment methods; and the MobilePay→Vipps migration tool now enforces nonce usage plus CSV type/size/row-count validation and sanitization.
> 
> Removes the REST debug endpoint’s `eval` execution and replaces it with a safe diagnostics payload, tightens webhook logging by sanitizing request metadata and redacting sensitive fields, and shortens/caps webhook secret caching with a filterable TTL.
> 
> Adds WooCommerce feature compatibility declarations for `cart_checkout_blocks` (in addition to HPOS) and adjusts “settled” status handling for subscription renewal orders by removing the webhook’s forced completion override. Also improves output escaping across multiple templates/tokens and restricts Vite dev-script injection to explicit debug modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d842045968d2a4e715529925a4b450961248881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->