### PR TITLE
v 1.8.13.1

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -4,7 +4,7 @@ Tags: Frisbii, billwerk+, visa, mastercard, dankort, mobilepay
 Requires at least: 4.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.8.13
+Stable tag: 1.8.13.1
 License: GPL
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.",
     "type": "wordpress-plugin",
     "license": "GPL",
-    "version": "1.8.13",
+    "version": "1.8.13.1",
     "autoload": {
         "psr-4": {
             "Reepay\\Checkout\\": "includes/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reepay-woocommerce-payment",
-  "version": "1.8.13",
+  "version": "1.8.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reepay-woocommerce-payment",
-      "version": "1.8.13",
+      "version": "1.8.13.1",
       "license": "SEE LICENSE IN License.txt",
       "dependencies": {
         "archiver": "^7.0.1",


### PR DESCRIPTION
v 1.8.13.1
- [Fix] - Updates WooCommerce supported version.
- [Fix] - The release of v1.8.13 on WordPress Plugin Directory had 2 old asset filenames.
- [Improvement] - Only loads Meta-fields and debug-page scripts where relevant and logs references to missing assets.
- [Improvement] - Backend notice about High Performance Order Storage is dismissible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string updates only; no application code changes in the diff.
> 
> **Overview**
> **Patch release `1.8.13.1`** — the visible diff only aligns version metadata across the plugin packaging files.
> 
> The **Stable tag** in `Readme.txt`, the **version** in `composer.json`, and the root **version** entries in `package-lock.json` are all updated from `1.8.13` to `1.8.13.1`. No PHP, JavaScript, or runtime logic changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4cc7c8158a885b9d9eb75779bd8308c49874f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->