### PR TITLE
v 1.8.15.2

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -4,7 +4,7 @@ Tags: Frisbii, billwerk+, visa, mastercard, dankort, mobilepay
 Requires at least: 4.0
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 1.8.15.1
+Stable tag: 1.8.15.2
 License: GPL
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 
@@ -18,6 +18,9 @@ The Frisbii Pay plugin extends WooCommerce allowing you to take payments on your
 See installation guide right here: https://docu.billwerk.plus/help/en/apps/woocommerce/setup-woocommerce-plugin.html
 
 == Changelog ==
+v 1.8.15.2
+- [Fix] – Instant settle setting does not interfere with Auto-settle.
+
 v 1.8.15.1
 - [Fix] – Auto-settle works with "Processing" as status of settled orders.
 - [Feature] – Age verification result data is added to order meta data.

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -187,6 +187,10 @@ jQuery(document).ready(function ($) {
         if (amount > 0 && settled < authorized && $("#order_status option:selected").val() === 'wc-completed') {
             e.preventDefault();
             const settle = window.confirm(`'You are about to change the order status. Do you want to capture the remaining amount of ${formatted_amount} ${currency} at the same time? Click OK to continue with settle. Click Cancel to continue without settle.'`)
+            // Cancel must abort the whole action - no status change, no settle.
+            if (!settle) {
+                return;
+            }
 
             $.ajax({
                 url: Reepay_Admin.ajax_url,
@@ -195,7 +199,7 @@ jQuery(document).ready(function ($) {
                     action: 'reepay_set_complete_settle_transient',
                     nonce: Reepay_Admin.nonce,
                     order_id: orderId,
-                    settle_order: Number(settle)
+                    settle_order: 1
                 },
                 beforeSend: function () {
                 },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.",
     "type": "wordpress-plugin",
     "license": "GPL",
-    "version": "1.8.15.1",
+    "version": "1.8.15.2",
     "autoload": {
         "psr-4": {
             "Reepay\\Checkout\\": "includes/",

--- a/includes/OrderFlow/OrderCapture.php
+++ b/includes/OrderFlow/OrderCapture.php
@@ -230,26 +230,8 @@ class OrderCapture {
 				return;
 			}
 
-			// BWPM-249: When auto-triggered, skip multi_settle() if any item does not qualify.
-			if ( false === $value ) {
-				$settle_types = reepay()->get_setting( 'settle' ) ?: array();
-				if ( ! empty( $settle_types ) ) {
-					foreach ( $order->get_items() as $item ) {
-						$product = $item->get_product();
-						if ( $product && ! InstantSettle::can_product_be_settled_instantly( $product ) ) {
-							$this->log(
-								array(
-									__METHOD__,
-									__LINE__,
-									'order' => $order_id,
-									'msg'   => 'Skipping auto-settle: order has item(s) not qualifying under settle_types. Deferring to InstantSettle.',
-								)
-							);
-							return;
-						}
-					}
-				}
-			}
+			// BWPM-270: Instant Settle controls settlement at authorization.
+			// Auto-settle on Completed is separate and must capture the order regardless of settle_types.
 
 			$this->log(
 				array(

--- a/includes/OrderFlow/OrderStatuses.php
+++ b/includes/OrderFlow/OrderStatuses.php
@@ -510,6 +510,19 @@ class OrderStatuses {
 					)
 				);
 
+				// BWPM-270/BWPM-265: Skip only for the real authorization event, not when
+				// the order should be settled. Otherwise, if Authorized and Settled use the
+				// same WC status (e.g. Processing), the order may be captured too early.
+				if ( false === $value && self::$status_authorized === $to ) {
+					$this->log(
+						sprintf(
+							'Order ID %d - skipping auto-settle: status_authorized equals status_settled — authorization event, not a settle intent.',
+							$order_id
+						)
+					);
+					break;
+				}
+
 				if ( ( '1' === $value || false === $value ) && $gateway->can_capture( $order ) ) {
 					try {
 						$order_data = reepay()->api( $gateway )->get_invoice_data( $order );
@@ -518,8 +531,10 @@ class OrderStatuses {
 						}
 
 						$amount_to_capture = rp_make_initial_amount( $order_data['authorized_amount'] - $order_data['settled_amount'], $order->get_currency() );
-						$items_to_capture  = InstantSettle::calculate_instant_settle( $order )['items'];
-						if ( ! empty( $items_to_capture ) && $amount_to_capture > 0 ) {
+						// BWPM-270: Instant Settle only controls settlement at authorization.
+						// Auto-settle on Completed must capture the full remaining amount when enabled,
+						// regardless of the product type selected for Instant Settle.
+						if ( $amount_to_capture > 0 ) {
 							$amount_to_capture = rp_prepare_amount( $amount_to_capture, $order->get_currency() );
 							$gateway->capture_payment( $order, $amount_to_capture );
 						}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reepay-woocommerce-payment",
-  "version": "1.8.15.1",
+  "version": "1.8.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reepay-woocommerce-payment",
-      "version": "1.8.15.1",
+      "version": "1.8.15.2",
       "license": "SEE LICENSE IN License.txt",
       "dependencies": {
         "archiver": "^7.0.1",
@@ -1132,6 +1132,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reepay-woocommerce-payment",
-  "version": "1.8.15.1",
+  "version": "1.8.15.2",
   "description": "",
   "main": "gulpfile.js",
   "dependencies": {

--- a/reepay-woocommerce-payment.php
+++ b/reepay-woocommerce-payment.php
@@ -4,7 +4,7 @@
  * Description: Get a plug-n-play payment solution for WooCommerce, that is easy to use, highly secure and is built to maximize the potential of your e-commerce.
  * Author: Frisbii
  * Author URI: https://frisbii.com
- * Version: 1.8.15.1
+ * Version: 1.8.15.2
  * Text Domain: reepay-checkout-gateway
  * Domain Path: /languages
  * WC requires at least: 3.0.0

--- a/tests/unit/orderFlow/OrderCaptureTest.php
+++ b/tests/unit/orderFlow/OrderCaptureTest.php
@@ -1399,6 +1399,68 @@ class OrderCaptureTest extends Reepay_UnitTestCase {
 		$this->order_capture->capture_full_order( $order_id, 'processing', 'completed', $order );
 	}
 
+	/**
+	 * Regression test for BWPM-270: a genuinely programmatic transition to "completed"
+	 * (e.g. REST API, WP-CLI, another plugin calling $order->update_status('completed')
+	 * directly — no admin dialog, no bulk action, so the settle-intent transient is
+	 * never set) must still auto-settle when Auto-settle is enabled, even if the order
+	 * contains an item whose type is not selected in the Instant Settle "settle_types"
+	 * setting. settle_types governs what gets settled instantly at authorization time;
+	 * it must not gate Auto-settle-on-completed.
+	 *
+	 * @group orderflow_capture
+	 */
+	public function test_capture_full_order_settles_physical_item_on_programmatic_completion_despite_non_qualifying_settle_types() {
+		self::$options->set_options(
+			array(
+				'status_authorized'   => 'processing',
+				'status_settled'      => 'processing',
+				'disable_auto_settle' => 'no',
+				'settle'              => array( 'online_virtual' ), // physical intentionally excluded.
+			)
+		);
+
+		$this->order_generator->set_prop( 'payment_method', reepay()->gateways()->checkout()->id );
+		$this->order_generator->add_product( 'simple', array( 'regular_price' => '20.00' ) );
+		$this->order_generator->order()->calculate_totals();
+		$this->order_generator->order()->save();
+
+		$order    = $this->order_generator->order();
+		$order_id = $order->get_id();
+
+		// Make sure the item is physical (needs shipping, not virtual/downloadable) so it
+		// would normally be excluded by the settle_types check.
+		foreach ( $order->get_items() as $item ) {
+			$product = $item->get_product();
+			$product->set_virtual( false );
+			$product->set_downloadable( false );
+			$product->save();
+		}
+
+		// No dialog, no bulk action — the transient was never set.
+		delete_transient( 'reepay_order_complete_should_settle_' . $order_id );
+
+		$this->api_mock->method( 'get_invoice_data' )->willReturn(
+			array(
+				'authorized_amount' => 2000,
+				'settled_amount'    => 0,
+				'refunded_amount'   => 0,
+				'order_lines'       => array(),
+			)
+		);
+		$this->api_mock->expects( $this->once() )->method( 'settle' )->willReturn(
+			array(
+				'state'             => 'settled',
+				'amount'            => 2000,
+				'authorized_amount' => 2000,
+			)
+		);
+
+		// Simulate a purely programmatic transition, e.g. an external system calling
+		// $order->update_status( 'completed' ) directly.
+		$this->order_capture->capture_full_order( $order_id, 'processing', 'completed', $order );
+	}
+
 	// -----------------------------------------------------------------------
 	// settle_amount()
 	// -----------------------------------------------------------------------

--- a/tests/unit/orderFlow/OrderStatusesTest.php
+++ b/tests/unit/orderFlow/OrderStatusesTest.php
@@ -710,4 +710,107 @@ class OrderStatusesTest extends Reepay_UnitTestCase {
 
 		$this->assertSame( 'on-hold', $result );
 	}
+
+	// -----------------------------------------------------------------------
+	// order_status_changed()
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Regression test for BWPM-270: the "Status: Frisbii Pay Settled" capture path in
+	 * OrderStatuses::order_status_changed() must capture the full remaining amount when
+	 * Auto-settle is enabled and the order transitions to the configured settled status,
+	 * even if the order's item type (e.g. physical) isn't selected in the Instant Settle
+	 * "settle_types" setting. settle_types governs instant settlement at authorization
+	 * time, not this capture-on-completion path.
+	 *
+	 * @group orderflow_statuses
+	 */
+	public function test_order_status_changed_captures_physical_item_despite_non_qualifying_settle_types() {
+		self::$options->set_options(
+			array(
+				'enable_sync'          => 'yes',
+				'status_settled'       => 'completed',
+				'disable_auto_settle'  => 'no',
+				'settle'               => array( 'online_virtual' ), // physical intentionally excluded.
+			)
+		);
+		OrderStatuses::init_statuses();
+
+		$this->order_generator->set_prop( 'payment_method', reepay()->gateways()->checkout()->id );
+		$this->order_generator->add_product( 'simple', array( 'regular_price' => '20.00' ) );
+		$this->order_generator->order()->calculate_totals();
+		$this->order_generator->order()->save();
+
+		$order = $this->order_generator->order();
+
+		// Make sure the item is physical (needs shipping, not virtual/downloadable) so it
+		// would normally be excluded by InstantSettle::calculate_instant_settle().
+		foreach ( $order->get_items() as $item ) {
+			$product = $item->get_product();
+			$product->set_virtual( false );
+			$product->set_downloadable( false );
+			$product->save();
+		}
+
+		delete_transient( 'reepay_order_complete_should_settle_' . $order->get_id() );
+
+		$this->api_mock->method( 'can_capture' )->willReturn( true );
+		$this->api_mock->method( 'get_invoice_data' )->willReturn(
+			array(
+				'authorized_amount' => 2000,
+				'settled_amount'    => 0,
+				'refunded_amount'   => 0,
+			)
+		);
+		$this->api_mock->expects( $this->once() )->method( 'capture_payment' );
+
+		$this->order_statuses->order_status_changed( $order->get_id(), 'processing', 'completed', $order );
+	}
+
+	/**
+	 * Regression test: when "Status: Frisbii Pay Authorized" and "Status: Frisbii Pay
+	 * Settled" are configured to the SAME WooCommerce status (e.g. both "Processing"),
+	 * the very first pending -> processing transition is the AUTHORIZATION event, not a
+	 * genuine settle intent. OrderCapture::capture_full_order() already guards against
+	 * mistaking this for a settle trigger (BWPM-249/BWPM-265); order_status_changed() must
+	 * have the same guard, otherwise the order gets captured prematurely at authorization
+	 * instead of waiting for the admin to actually complete the order — contradicting the
+	 * client's own BWPM-265 expectation ("I expected the orders to get settled when their
+	 * status change to completed").
+	 *
+	 * @group orderflow_statuses
+	 */
+	public function test_order_status_changed_skips_genuine_authorization_event_when_settled_equals_authorized() {
+		self::$options->set_options(
+			array(
+				'enable_sync'         => 'yes',
+				'status_authorized'   => 'processing',
+				'status_settled'      => 'processing',
+				'disable_auto_settle' => 'no',
+			)
+		);
+		OrderStatuses::init_statuses();
+
+		$this->order_generator->set_prop( 'payment_method', reepay()->gateways()->checkout()->id );
+		$this->order_generator->add_product( 'simple', array( 'regular_price' => '20.00' ) );
+		$this->order_generator->order()->calculate_totals();
+		$this->order_generator->order()->save();
+
+		$order = $this->order_generator->order();
+
+		delete_transient( 'reepay_order_complete_should_settle_' . $order->get_id() );
+
+		$this->api_mock->method( 'can_capture' )->willReturn( true );
+		$this->api_mock->method( 'get_invoice_data' )->willReturn(
+			array(
+				'authorized_amount' => 2000,
+				'settled_amount'    => 0,
+				'refunded_amount'   => 0,
+			)
+		);
+		$this->api_mock->expects( $this->never() )->method( 'capture_payment' );
+
+		// Simulate the real authorization event: pending -> processing.
+		$this->order_statuses->order_status_changed( $order->get_id(), 'pending', 'processing', $order );
+	}
 }

--- a/vite/package.json
+++ b/vite/package.json
@@ -73,7 +73,8 @@
         "vite-plugin-monaco-editor": "^1.1.0"
     },
     "overrides": {
-        "minimatch": ">=10.2.3"
+        "minimatch": ">=10.2.3",
+         "dompurify": ">=3.4.13"
     },
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5"


### PR DESCRIPTION
v 1.8.15.2
- [Fix] – Instant settle setting does not interfere with Auto-settle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes capture timing for WooCommerce order completion, so orders that Instant Settle previously skipped may now be charged when Auto-settle is on. A guard remains so authorization is not treated as settle when Authorized and Settled share a status.
> 
> **Overview**
> **Instant Settle no longer gates Auto-settle on completion.** Completing an order (admin, bulk, REST/WP-CLI, or status sync) captures the remaining authorized amount even when product types are excluded from Instant Settle `settle_types`. Instant Settle still only applies at authorization.
> 
> `OrderCapture::capture_full_order()` drops the skip that deferred to Instant Settle when items did not qualify. `OrderStatuses::order_status_changed()` captures the full remaining amount instead of Instant Settle line items, and skips capture only on a real authorization event when Authorized and Settled share the same WC status.
> 
> Canceling the admin “capture remaining amount?” dialog now aborts the whole save (no status change). Confirm always sets the settle-intent transient to `1`.
> 
> Regression tests cover programmatic completion of physical items and the same-status authorization skip. Plugin version is **1.8.15.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435fe398dc8f491d330390fb0f6f2a77f3849b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->